### PR TITLE
fixes #16 and #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test-tmp
 src/gen
 src/main/resources/vertx-js/*.js
 src/test/resources/vertx-js/*.js
+derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,13 @@
       <version>2.3.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>10.11.1.1</version>
+      <scope>test</scope>
+    </dependency>
+
 
   </dependencies>
 </project>

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -109,12 +109,12 @@ This will return the connection in the handler when one is ready from the pool.
 
 # Now do stuff with it:
 
-client.get_connection() { |res,res_err|
+client.get_connection() { |res_err,res|
   if (res_err == nil)
 
     connection = res
 
-    connection.query("SELECT * FROM some_table") { |res2,res2_err|
+    connection.query("SELECT * FROM some_table") { |res2_err,res2|
       if (res2_err == nil)
 
         rs = res2

--- a/src/main/generated/io/vertx/rxjava/ext/jdbc/JDBCClient.java
+++ b/src/main/generated/io/vertx/rxjava/ext/jdbc/JDBCClient.java
@@ -120,6 +120,6 @@ public class JDBCClient {
 
 
   public static JDBCClient newInstance(io.vertx.ext.jdbc.JDBCClient arg) {
-    return new JDBCClient(arg);
+    return arg != null ? new JDBCClient(arg) : null;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/ext/jdbc/JDBCClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/jdbc/JDBCClient.groovy
@@ -41,7 +41,7 @@ public class JDBCClient {
    * @return the client
    */
   public static JDBCClient createNonShared(Vertx vertx, Map<String, Object> config) {
-    def ret= new io.vertx.groovy.ext.jdbc.JDBCClient(io.vertx.ext.jdbc.JDBCClient.createNonShared((io.vertx.core.Vertx)vertx.getDelegate(), config != null ? new io.vertx.core.json.JsonObject(config) : null));
+    def ret= InternalHelper.safeCreate(io.vertx.ext.jdbc.JDBCClient.createNonShared((io.vertx.core.Vertx)vertx.getDelegate(), config != null ? new io.vertx.core.json.JsonObject(config) : null), io.vertx.ext.jdbc.JDBCClient.class, io.vertx.groovy.ext.jdbc.JDBCClient.class);
     return ret;
   }
   /**
@@ -53,7 +53,7 @@ public class JDBCClient {
    * @return the client
    */
   public static JDBCClient createShared(Vertx vertx, Map<String, Object> config, String dataSourceName) {
-    def ret= new io.vertx.groovy.ext.jdbc.JDBCClient(io.vertx.ext.jdbc.JDBCClient.createShared((io.vertx.core.Vertx)vertx.getDelegate(), config != null ? new io.vertx.core.json.JsonObject(config) : null, dataSourceName));
+    def ret= InternalHelper.safeCreate(io.vertx.ext.jdbc.JDBCClient.createShared((io.vertx.core.Vertx)vertx.getDelegate(), config != null ? new io.vertx.core.json.JsonObject(config) : null, dataSourceName), io.vertx.ext.jdbc.JDBCClient.class, io.vertx.groovy.ext.jdbc.JDBCClient.class);
     return ret;
   }
   /**
@@ -63,7 +63,7 @@ public class JDBCClient {
    * @return the client
    */
   public static JDBCClient createShared(Vertx vertx, Map<String, Object> config) {
-    def ret= new io.vertx.groovy.ext.jdbc.JDBCClient(io.vertx.ext.jdbc.JDBCClient.createShared((io.vertx.core.Vertx)vertx.getDelegate(), config != null ? new io.vertx.core.json.JsonObject(config) : null));
+    def ret= InternalHelper.safeCreate(io.vertx.ext.jdbc.JDBCClient.createShared((io.vertx.core.Vertx)vertx.getDelegate(), config != null ? new io.vertx.core.json.JsonObject(config) : null), io.vertx.ext.jdbc.JDBCClient.class, io.vertx.groovy.ext.jdbc.JDBCClient.class);
     return ret;
   }
   /**

--- a/src/main/resources/vertx-jdbc-js/jdbc_client.js
+++ b/src/main/resources/vertx-jdbc-js/jdbc_client.js
@@ -45,7 +45,7 @@ var JDBCClient = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_jDBCClient["getConnection(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        handler(new SQLConnection(ar.result()), null);
+        handler(utils.convReturnVertxGen(ar.result(), SQLConnection), null);
       } else {
         handler(null, ar.cause());
       }
@@ -84,7 +84,7 @@ var JDBCClient = function(j_val) {
 JDBCClient.createNonShared = function(vertx, config) {
   var __args = arguments;
   if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object') {
-    return new JDBCClient(JJDBCClient["createNonShared(io.vertx.core.Vertx,io.vertx.core.json.JsonObject)"](vertx._jdel, utils.convParamJsonObject(config)));
+    return utils.convReturnVertxGen(JJDBCClient["createNonShared(io.vertx.core.Vertx,io.vertx.core.json.JsonObject)"](vertx._jdel, utils.convParamJsonObject(config)), JDBCClient);
   } else utils.invalidArgs();
 };
 
@@ -101,9 +101,9 @@ JDBCClient.createNonShared = function(vertx, config) {
 JDBCClient.createShared = function() {
   var __args = arguments;
   if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object') {
-    return new JDBCClient(JJDBCClient["createShared(io.vertx.core.Vertx,io.vertx.core.json.JsonObject)"](__args[0]._jdel, utils.convParamJsonObject(__args[1])));
+    return utils.convReturnVertxGen(JJDBCClient["createShared(io.vertx.core.Vertx,io.vertx.core.json.JsonObject)"](__args[0]._jdel, utils.convParamJsonObject(__args[1])), JDBCClient);
   }else if (__args.length === 3 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object' && typeof __args[2] === 'string') {
-    return new JDBCClient(JJDBCClient["createShared(io.vertx.core.Vertx,io.vertx.core.json.JsonObject,java.lang.String)"](__args[0]._jdel, utils.convParamJsonObject(__args[1]), __args[2]));
+    return utils.convReturnVertxGen(JJDBCClient["createShared(io.vertx.core.Vertx,io.vertx.core.json.JsonObject,java.lang.String)"](__args[0]._jdel, utils.convParamJsonObject(__args[1]), __args[2]), JDBCClient);
   } else utils.invalidArgs();
 };
 

--- a/src/main/resources/vertx-jdbc/jdbc_client.rb
+++ b/src/main/resources/vertx-jdbc/jdbc_client.rb
@@ -20,7 +20,7 @@ module VertxJdbc
     # @return [::VertxJdbc::JDBCClient] the client
     def self.create_non_shared(vertx=nil,config=nil)
       if vertx.class.method_defined?(:j_del) && config.class == Hash && !block_given?
-        return ::VertxJdbc::JDBCClient.new(Java::IoVertxExtJdbc::JDBCClient.java_method(:createNonShared, [Java::IoVertxCore::Vertx.java_class,Java::IoVertxCoreJson::JsonObject.java_class]).call(vertx.j_del,::Vertx::Util::Utils.to_json_object(config)))
+        return ::Vertx::Util::Utils.safe_create(Java::IoVertxExtJdbc::JDBCClient.java_method(:createNonShared, [Java::IoVertxCore::Vertx.java_class,Java::IoVertxCoreJson::JsonObject.java_class]).call(vertx.j_del,::Vertx::Util::Utils.to_json_object(config)),::VertxJdbc::JDBCClient)
       end
       raise ArgumentError, "Invalid arguments when calling create_non_shared(vertx,config)"
     end
@@ -32,9 +32,9 @@ module VertxJdbc
     # @return [::VertxJdbc::JDBCClient] the client
     def self.create_shared(vertx=nil,config=nil,dataSourceName=nil)
       if vertx.class.method_defined?(:j_del) && config.class == Hash && !block_given? && dataSourceName == nil
-        return ::VertxJdbc::JDBCClient.new(Java::IoVertxExtJdbc::JDBCClient.java_method(:createShared, [Java::IoVertxCore::Vertx.java_class,Java::IoVertxCoreJson::JsonObject.java_class]).call(vertx.j_del,::Vertx::Util::Utils.to_json_object(config)))
+        return ::Vertx::Util::Utils.safe_create(Java::IoVertxExtJdbc::JDBCClient.java_method(:createShared, [Java::IoVertxCore::Vertx.java_class,Java::IoVertxCoreJson::JsonObject.java_class]).call(vertx.j_del,::Vertx::Util::Utils.to_json_object(config)),::VertxJdbc::JDBCClient)
       elsif vertx.class.method_defined?(:j_del) && config.class == Hash && dataSourceName.class == String && !block_given?
-        return ::VertxJdbc::JDBCClient.new(Java::IoVertxExtJdbc::JDBCClient.java_method(:createShared, [Java::IoVertxCore::Vertx.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::java.lang.String.java_class]).call(vertx.j_del,::Vertx::Util::Utils.to_json_object(config),dataSourceName))
+        return ::Vertx::Util::Utils.safe_create(Java::IoVertxExtJdbc::JDBCClient.java_method(:createShared, [Java::IoVertxCore::Vertx.java_class,Java::IoVertxCoreJson::JsonObject.java_class,Java::java.lang.String.java_class]).call(vertx.j_del,::Vertx::Util::Utils.to_json_object(config),dataSourceName),::VertxJdbc::JDBCClient)
       end
       raise ArgumentError, "Invalid arguments when calling create_shared(vertx,config,dataSourceName)"
     end
@@ -44,7 +44,7 @@ module VertxJdbc
     # @return [self]
     def get_connection
       if block_given?
-        @j_del.java_method(:getConnection, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ::VertxSql::SQLConnection.new(ar.result) : nil) }))
+        @j_del.java_method(:getConnection, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ::Vertx::Util::Utils.safe_create(ar.result,::VertxSql::SQLConnection) : nil) }))
         return self
       end
       raise ArgumentError, "Invalid arguments when calling get_connection()"

--- a/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
@@ -205,7 +205,7 @@ public abstract class JDBCClientTestBase extends VertxTestBase {
       conn.queryWithParams("SElECT DOB FROM insert_table WHERE id=?;", new JsonArray().add(id), onSuccess(resultSet -> {
         assertNotNull(resultSet);
         assertEquals(1, resultSet.getResults().size());
-        assertEquals("2002-02-02", resultSet.getResults().get(0).getString(0));
+        assertEquals("2002-02-01T23:00:00Z", resultSet.getResults().get(0).getString(0));
         testComplete();
       }));
     }));

--- a/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
@@ -53,6 +53,7 @@ public abstract class JDBCClientTestBase extends VertxTestBase {
     SQL.add("drop table if exists insert_table;");
     SQL.add("drop table if exists update_table;");
     SQL.add("drop table if exists delete_table;");
+    SQL.add("drop table if exists blob_table;");
     SQL.add("create table select_table (id int, lname varchar(255), fname varchar(255) );");
     SQL.add("insert into select_table values (1, 'doe', 'john');");
     SQL.add("insert into select_table values (2, 'doe', 'jane');");
@@ -62,10 +63,13 @@ public abstract class JDBCClientTestBase extends VertxTestBase {
     SQL.add("create table delete_table (id int, lname varchar(255), fname varchar(255), dob date );");
     SQL.add("insert into delete_table values (1, 'doe', 'john', '2001-01-01');");
     SQL.add("insert into delete_table values (2, 'doe', 'jane', '2002-02-02');");
+    SQL.add("create table blob_table (b blob, c clob, a int array default array[]);");
+    SQL.add("insert into blob_table (b, c, a) values (load_file('pom.xml'), convert('Hello', clob),  ARRAY[1,2,3])");
   }
 
   @BeforeClass
   public static void createDb() throws Exception {
+    System.setProperty("textdb.allow_full_path", "true");
     Connection conn = DriverManager.getConnection(config().getString("url"));
     for (String sql : SQL) {
       conn.createStatement().execute(sql);
@@ -321,6 +325,45 @@ public abstract class JDBCClientTestBase extends VertxTestBase {
   @Test
   public void testRollback() throws Exception {
     testTx(5, false);
+  }
+
+  @Test
+  public void testBlob() {
+    String sql = "SELECT b FROM blob_table";
+    connection().query(sql, onSuccess(resultSet -> {
+      assertNotNull(resultSet);
+      assertEquals(1, resultSet.getResults().size());
+      assertNotNull(resultSet.getResults().get(0).getBinary(0));
+      testComplete();
+    }));
+
+    await();
+  }
+
+  @Test
+  public void testClob() {
+    String sql = "SELECT c FROM blob_table";
+    connection().query(sql, onSuccess(resultSet -> {
+      assertNotNull(resultSet);
+      assertEquals(1, resultSet.getResults().size());
+      assertNotNull(resultSet.getResults().get(0).getString(0));
+      testComplete();
+    }));
+
+    await();
+  }
+
+  @Test
+  public void testArray() {
+    String sql = "SELECT a FROM blob_table";
+    connection().query(sql, onSuccess(resultSet -> {
+      assertNotNull(resultSet);
+      assertEquals(1, resultSet.getResults().size());
+      assertNotNull(resultSet.getResults().get(0).getJsonArray(0));
+      testComplete();
+    }));
+
+    await();
   }
 
   private void testTx(int inserts, boolean commit) throws Exception {

--- a/src/test/java/io/vertx/ext/jdbc/JDBCTypesTestBase.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCTypesTestBase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.jdbc;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.sql.UpdateResult;
+import io.vertx.test.core.VertxTestBase;
+import org.jruby.RubyProcess;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ */
+public class JDBCTypesTestBase extends VertxTestBase {
+
+  protected JDBCClient client;
+
+  private static final List<String> SQL = new ArrayList<>();
+
+  static {
+    //TODO: Create table with more types for testing
+    SQL.add("create table insert_table (id int not null primary key generated always as identity (START WITH 1, INCREMENT BY 1), lname varchar(255), fname varchar(255), dob date )");
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    client = JDBCClient.createNonShared(vertx, config());
+  }
+
+  @After
+  public void after() throws Exception {
+    client.close();
+    super.after();
+  }
+
+  @BeforeClass
+  public static void createDb() throws Exception {
+    Connection conn = DriverManager.getConnection(config().getString("url"));
+    for (String sql : SQL) {
+      conn.createStatement().execute(sql);
+    }
+  }
+
+  protected static JsonObject config() {
+    return new JsonObject()
+      .put("url", "jdbc:derby:memory:myDB;create=true")
+      .put("driver_class", "org.apache.derby.jdbc.EmbeddedDriver");
+  }
+
+  @Test
+  public void testInsertWithNullParameters() {
+    SQLConnection conn = connection();
+    String sql = "INSERT INTO insert_table (lname, fname, dob) VALUES (?, ?, ?)";
+    JsonArray params = new JsonArray().addNull().addNull().add("2002-02-02");
+    conn.updateWithParams(sql, params, onSuccess(result -> {
+      assertUpdate(result, 1);
+      int id = result.getKeys().getInteger(0);
+      conn.queryWithParams("SElECT DOB FROM insert_table WHERE id=?", new JsonArray().add(id), onSuccess(resultSet -> {
+        assertNotNull(resultSet);
+        assertEquals(1, resultSet.getResults().size());
+
+        System.out.println(resultSet.getResults().get(0).getValue(0));
+        testComplete();
+      }));
+    }));
+
+    await();
+  }
+
+  private void assertUpdate(UpdateResult result, int updated) {
+    assertUpdate(result, updated, false);
+  }
+
+  private void assertUpdate(UpdateResult result, int updated, boolean generatedKeys) {
+    assertNotNull(result);
+    assertEquals(updated, result.getUpdated());
+    if (generatedKeys) {
+      JsonArray keys = result.getKeys();
+      assertNotNull(keys);
+      assertEquals(updated, keys.size());
+      Set<Integer> numbers = new HashSet<>();
+      for (int i = 0; i < updated; i++) {
+        assertTrue(keys.getValue(i) instanceof Integer);
+        assertTrue(numbers.add(i));
+      }
+    }
+  }
+
+  private SQLConnection connection() {
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<SQLConnection> ref = new AtomicReference<>();
+    client.getConnection(onSuccess(conn -> {
+      ref.set(conn);
+      latch.countDown();
+    }));
+
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    return ref.get();
+  }
+}


### PR DESCRIPTION
the conversion from JDBC to JSON types was incomplete, this new implementation fixes the issue and add a second DB test server (derby) that would reproduce the issues #16 and #17.

@purplefox @vietj please review.

Also note that the new implementation handles returned dates (DB -> JSON) in the same format as mongo-client for consistency. 