### PR TITLE
discard null generated keys to prevent exception

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
@@ -44,18 +44,18 @@ public class JDBCUpdate extends AbstractJDBCStatement<UpdateResult> {
   @Override
   protected UpdateResult executeStatement(PreparedStatement statement) throws SQLException {
     int updated = statement.executeUpdate();
-    JsonObject result = new JsonObject();
-    result.put("updated", updated);
     // Create JsonArray of keys
     ResultSet rs = statement.getGeneratedKeys();
     JsonArray keys = new JsonArray();
-    while (rs.next()) {
-      Object key = rs.getObject(1);
-      if (key!=null) {
-        keys.add(convertSqlValue(key));
+    if (rs!=null) {
+      while (rs.next()) {
+        Object key = rs.getObject(1);
+        if (key!=null) {
+          keys.add(convertSqlValue(key));
+        }
       }
+      rs.close();
     }
-    rs.close();
     return new UpdateResult(updated, keys);
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
@@ -50,7 +50,10 @@ public class JDBCUpdate extends AbstractJDBCStatement<UpdateResult> {
     ResultSet rs = statement.getGeneratedKeys();
     JsonArray keys = new JsonArray();
     while (rs.next()) {
-      keys.add(convertSqlValue(rs.getObject(1)));
+      Object key = rs.getObject(1);
+      if (key!=null) {
+        keys.add(convertSqlValue(key));
+      }
     }
     rs.close();
     return new UpdateResult(updated, keys);


### PR DESCRIPTION
jdbc (jtds with sql server and derby) return generated keys that are null or a null generated key resultset if there is no identity column in the table.
The test case was using jtds (1.3.1) to access a table in sql server 2008 where there is NO identity column. In this situation when doing an update, jtds returns null generatedKeys. The JDBCUpdate code was attempting to add the null key to the JsonArray and throwing an exception.
This proposed fix just discards the null key and also works if the returned result set is null.
Tested and works fine.
Unit test now included.

I hope this is acceptable.