### PR TITLE
Fixes vert-x3/vertx-sql-common#19: implement optimistic casting for temporal and UUID types in JDBC

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCStatementHelper.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCStatementHelper.java
@@ -17,25 +17,25 @@
 package io.vertx.ext.jdbc.impl.actions;
 
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.sql.*;
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.sql.Date;
+import java.time.*;
+import java.util.*;
 import java.util.regex.Pattern;
 
-import static java.time.format.DateTimeFormatter.ISO_INSTANT;
-import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.format.DateTimeFormatter.*;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 final class JDBCStatementHelper {
+
+  private static final Logger log = LoggerFactory.getLogger(JDBCStatementHelper.class);
 
   private static final JsonArray EMPTY = new JsonArray(Collections.unmodifiableList(new ArrayList<>()));
 
@@ -144,7 +144,7 @@ final class JDBCStatementHelper {
     return new io.vertx.ext.sql.ResultSet(columnNames, results);
   }
 
-  public static Object convertSqlValue(Object value) {
+  public static Object convertSqlValue(Object value) throws SQLException {
     if (value == null) {
       return null;
     }
@@ -170,7 +170,15 @@ final class JDBCStatementHelper {
     }
 
     // temporal values
-    if (value instanceof Date || value instanceof Time || value instanceof Timestamp) {
+    if (value instanceof Time) {
+      return ((Time) value).toLocalTime().atOffset(ZoneOffset.UTC).format(ISO_LOCAL_TIME);
+    }
+
+    if (value instanceof Date) {
+      return ((Date) value).toLocalDate().format(ISO_LOCAL_DATE);
+    }
+
+    if (value instanceof Timestamp) {
       return OffsetDateTime.ofInstant(Instant.ofEpochMilli(((java.util.Date) value).getTime()), ZoneOffset.UTC).format(ISO_OFFSET_DATE_TIME);
     }
 
@@ -179,12 +187,9 @@ final class JDBCStatementHelper {
       Clob c = (Clob) value;
       try {
         // result might be truncated due to downcasting to int
-        String tmp = c.getSubString(1, (int) c.length());
+        return c.getSubString(1, (int) c.length());
+      } finally {
         c.free();
-
-        return tmp;
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
       }
     }
 
@@ -192,11 +197,9 @@ final class JDBCStatementHelper {
       Blob b = (Blob) value;
       try {
         // result might be truncated due to downcasting to int
-        byte[] tmp = b.getBytes(1, (int) b.length());
+        return b.getBytes(1, (int) b.length());
+      } finally {
         b.free();
-        return tmp;
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
       }
     }
 
@@ -210,13 +213,10 @@ final class JDBCStatementHelper {
           for (Object o : arr) {
             jsonArray.add(convertSqlValue(o));
           }
-
-          a.free();
-
           return jsonArray;
         }
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
+      } finally {
+        a.free();
       }
     }
 
@@ -224,29 +224,45 @@ final class JDBCStatementHelper {
     return value.toString();
   }
 
-  private static Object optimisticCast(String value) {
+  public static Object optimisticCast(String value) {
     if (value == null) {
       return null;
     }
 
-    // sql time
-    if (TIME.matcher(value).matches()) {
-      return new java.sql.Time(Instant.from(ISO_INSTANT.parse("1900-01-01T" + value)).toEpochMilli());
-    }
+    try {
+      // sql time
+      if (TIME.matcher(value).matches()) {
+        // convert from local time to instant
+        Instant instant = LocalTime.parse(value).atDate(LocalDate.of(1970, 1, 1)).toInstant(ZoneOffset.UTC);
+        // calculate the timezone offset in millis
+        int offset = TimeZone.getDefault().getOffset(instant.toEpochMilli());
+        // need to remove the offset since time has no TZ component
+        return new Time(instant.toEpochMilli() - offset);
+      }
 
-    // sql date
-    if (DATE.matcher(value).matches()) {
-      return new java.sql.Date(Instant.from(ISO_INSTANT.parse(value + "T00:00:00Z")).toEpochMilli());
-    }
+      // sql date
+      if (DATE.matcher(value).matches()) {
+        // convert from local date to instant
+        Instant instant = LocalDate.parse(value).atTime(LocalTime.of(0, 0, 0, 0)).toInstant(ZoneOffset.UTC);
+        // calculate the timezone offset in millis
+        int offset = TimeZone.getDefault().getOffset(instant.toEpochMilli());
+        // need to remove the offset since time has no TZ component
+        return new Date(instant.toEpochMilli() - offset);
+      }
 
-    // sql timestamp
-    if (DATETIME.matcher(value).matches()) {
-      return new java.sql.Timestamp(Instant.from(ISO_INSTANT.parse(value)).toEpochMilli());
-    }
+      // sql timestamp
+      if (DATETIME.matcher(value).matches()) {
+        Instant instant = Instant.from(ISO_INSTANT.parse(value));
+        return new Timestamp(instant.toEpochMilli());
+      }
 
-    // sql uuid
-    if (UUID.matcher(value).matches()) {
-      return java.util.UUID.fromString(value);
+      // sql uuid
+      if (UUID.matcher(value).matches()) {
+        return java.util.UUID.fromString(value);
+      }
+
+    } catch (RuntimeException e) {
+      log.debug(e);
     }
 
     // unknown

--- a/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
@@ -210,7 +210,7 @@ public abstract class JDBCClientTestBase extends VertxTestBase {
       conn.queryWithParams("SElECT DOB FROM insert_table WHERE id=?;", new JsonArray().add(id), onSuccess(resultSet -> {
         assertNotNull(resultSet);
         assertEquals(1, resultSet.getResults().size());
-        assertEquals("2002-02-02T00:00:00Z", resultSet.getResults().get(0).getString(0));
+        assertEquals("2002-02-02", resultSet.getResults().get(0).getString(0));
         TimeZone.setDefault(tz);
         testComplete();
       }));

--- a/src/test/java/io/vertx/ext/jdbc/JDBCCustomTypesTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCCustomTypesTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.jdbc;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.test.core.VertxTestBase;
@@ -28,6 +29,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -86,6 +88,23 @@ public class JDBCCustomTypesTest extends VertxTestBase {
     await();
   }
 
+  @Test
+  public void testCustomInsert() {
+    String sql = "INSERT INTO t (u) VALUES (?)";
+    final String uuid = UUID.randomUUID().toString();
+
+    final SQLConnection conn = connection();
+
+    conn.setAutoCommit(false, tx -> {
+      if (tx.succeeded()) {
+        conn.updateWithParams(sql, new JsonArray().add(uuid), onSuccess(resultSet -> {
+          testComplete();
+        }));
+      }
+    });
+
+    await();
+  }
 
   private SQLConnection connection() {
     CountDownLatch latch = new CountDownLatch(1);

--- a/src/test/java/io/vertx/ext/jdbc/JDBCCustomTypesTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCCustomTypesTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -44,7 +45,7 @@ public class JDBCCustomTypesTest extends VertxTestBase {
 
   static {
     SQL.add("drop table if exists t");
-    SQL.add("create table t (u UUID)");
+    SQL.add("create table t (u UUID, d DATE, t TIME, ts TIMESTAMP)");
     SQL.add("insert into t (u) values (random_uuid())");
   }
 
@@ -90,14 +91,14 @@ public class JDBCCustomTypesTest extends VertxTestBase {
 
   @Test
   public void testCustomInsert() {
-    String sql = "INSERT INTO t (u) VALUES (?)";
+    String sql = "INSERT INTO t (u, t, d, ts) VALUES (?, ?, ?, ?)";
     final String uuid = UUID.randomUUID().toString();
 
     final SQLConnection conn = connection();
 
     conn.setAutoCommit(false, tx -> {
       if (tx.succeeded()) {
-        conn.updateWithParams(sql, new JsonArray().add(uuid), onSuccess(resultSet -> {
+        conn.updateWithParams(sql, new JsonArray().add(uuid).add("09:00:00").add("2015-03-16").add(Instant.now()), onSuccess(resultSet -> {
           testComplete();
         }));
       }

--- a/src/test/java/io/vertx/ext/jdbc/impl/actions/OptimisticCastTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/impl/actions/OptimisticCastTest.java
@@ -1,0 +1,43 @@
+package io.vertx.ext.jdbc.impl.actions;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class OptimisticCastTest {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> generateData() {
+    return Arrays.asList(new Object[][]{
+        // simple types
+        {"16:00:00", "java.sql.Time"},
+        {"2016-03-16", "java.sql.Date"},
+        {"2016-03-16T16:00:00Z", "java.sql.Timestamp"},
+        {"f47ac10b-58cc-4372-a567-0e02b2c3d479", "java.util.UUID"},
+        // bad variations
+        {"2016-03-16T16:00:00", "java.lang.String"},
+        {"24:00:00", "java.lang.String"},
+        {"2016-00-00", "java.lang.String"},
+    });
+  }
+
+  // Fields
+  private String value;
+  private String expectedType;
+
+  public OptimisticCastTest(String value, String expectedType) {
+    this.value = value;
+    this.expectedType = expectedType;
+  }
+
+  @Test
+  public void testOptimisticCast() {
+    assertEquals(value, expectedType, JDBCStatementHelper.optimisticCast(value).getClass().getName());
+  }
+}

--- a/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
@@ -1,0 +1,42 @@
+package io.vertx.ext.jdbc.impl.actions;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class SQLConvertTest {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> generateData() {
+    return Arrays.asList(new Object[][] {
+        // simple types
+        {"16:00:00"},
+        {"2016-03-16"},
+        {"2016-03-16T16:00:00Z"},
+        {"f47ac10b-58cc-4372-a567-0e02b2c3d479"},
+    });
+  }
+
+  // Fields
+  private String value;
+
+  public SQLConvertTest(String value) {
+    this.value = value;
+  }
+
+  @Test
+  public void testSQLConvert() throws SQLException {
+    Object cast = JDBCStatementHelper.optimisticCast(value);
+    Object convert = JDBCStatementHelper.convertSqlValue(cast);
+
+    assertEquals(value, convert);
+  }
+}


### PR DESCRIPTION
Fixes vert-x3/vertx-sql-common#19

Implemented a optimistic cast for JDBC types for now it decodes, temporal types plus UUID