### PR TITLE
c3p0 should not be an optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
               javax.sql,
               io.vertx.ext.sql*,
               io.vertx.core*,
+              com.mchange.*,
               *;resolution:=optional</Import-Package>
             <Include-Resource>{maven-resources}</Include-Resource>
           </instructions>


### PR DESCRIPTION
c3p0 is not an optional dependency, it throws a cnf exception as soon as the bundle starts. This should be reflected as a normal import package.