### PR TITLE
Fix HikariCPDataSourceProvider

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/spi/impl/HikariCPDataSourceProvider.java
+++ b/src/main/java/io/vertx/ext/jdbc/spi/impl/HikariCPDataSourceProvider.java
@@ -107,7 +107,7 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
           config.setValidationTimeout(getLong(entry.getValue()));
           break;
         case "leakDetectionThreshold":
-          config.setLeakDetectionThreshold((Long) entry.getValue());
+          config.setLeakDetectionThreshold(getLong(entry.getValue()));
           break;
         case "dataSource":
           throw new UnsupportedOperationException(entry.getKey());

--- a/src/test/java/io/vertx/ext/jdbc/spi/impl/HikariCPDataSourceProviderTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/spi/impl/HikariCPDataSourceProviderTest.java
@@ -54,4 +54,22 @@ public class HikariCPDataSourceProviderTest {
     provider.close(dataSource);
   }
 
+
+  @Test
+  public void testLeakDetectionOfTheHikariCPDataSourceWithLong() throws SQLException {
+    HikariCPDataSourceProvider provider = new HikariCPDataSourceProvider();
+
+    JsonObject configuration = new JsonObject();
+    configuration
+            .put("foo", "bar")
+            .put("jdbcUrl", "jdbc:hsqldb:mem:test?shutdown=true")
+            .put("leakDetectionThreshold", 10000);
+
+    DataSource dataSource = provider.getDataSource(configuration);
+    assertNotNull(dataSource);
+    assertNotNull(dataSource.getConnection());
+
+    provider.close(dataSource);
+  }
+
 }


### PR DESCRIPTION
Hi.

I've fixed a small bug of HikariCPDataSourceProvider.
When we use leakDetectionThreshold, it will fail due to ClassCastException.

```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
```