### PR TITLE
Correct "UUIDCast" to "castUUID"

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -219,7 +219,7 @@ are supported by many databases but not all. For example MySQL does not support 
 a VARCHAR(36) column. For other engines UUID optimistic casting can be enabled using the client config json as:
 
 ----
-{ "UUIDCast": true }
+{ "castUUID": true }
 ----
 
 When this config is present UUIDs will be handled as a native type.

--- a/src/main/java/io/vertx/ext/jdbc/package-info.java
+++ b/src/main/java/io/vertx/ext/jdbc/package-info.java
@@ -215,7 +215,7 @@
  * a VARCHAR(36) column. For other engines UUID optimistic casting can be enabled using the client config json as:
  *
  * ----
- * { "UUIDCast": true }
+ * { "castUUID": true }
  * ----
  *
  * When this config is present UUIDs will be handled as a native type.


### PR DESCRIPTION
The documentation refers to setting "UUIDCast" in the JSON config object but the extension actually uses "castUUID". See the JDBCStatementHelper.java

```
  public JDBCStatementHelper(JsonObject config) {
    this.castUUID = config.getBoolean("castUUID", false);
  }
```