### PR TITLE
Fixes Instant/Timestamp conversion

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCStatementHelper.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCStatementHelper.java
@@ -22,10 +22,29 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
 import java.math.BigDecimal;
-import java.sql.*;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
 import java.sql.Date;
-import java.time.*;
-import java.util.*;
+import java.sql.JDBCType;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
 import java.util.regex.Pattern;
 
 import static java.time.format.DateTimeFormatter.*;
@@ -40,7 +59,7 @@ public final class JDBCStatementHelper {
 
   private static final JsonArray EMPTY = new JsonArray(Collections.unmodifiableList(new ArrayList<>()));
 
-  private static final Pattern DATETIME = Pattern.compile("^\\d{4}-(?:0[0-9]|1[0-2])-[0-9]{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?Z$");
+  private static final Pattern DATETIME = Pattern.compile("^\\d{4}-(?:0[0-9]|1[0-2])-[0-9]{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3,9})?Z$");
   private static final Pattern DATE = Pattern.compile("^\\d{4}-(?:0[0-9]|1[0-2])-[0-9]{2}$");
   private static final Pattern TIME = Pattern.compile("^\\d{2}:\\d{2}:\\d{2}$");
   private static final Pattern UUID = Pattern.compile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$");
@@ -193,7 +212,7 @@ public final class JDBCStatementHelper {
     }
 
     if (value instanceof Timestamp) {
-      return OffsetDateTime.ofInstant(Instant.ofEpochMilli(((java.util.Date) value).getTime()), ZoneOffset.UTC).format(ISO_OFFSET_DATE_TIME);
+      return OffsetDateTime.ofInstant(((Timestamp) value).toInstant(), ZoneOffset.UTC).format(ISO_OFFSET_DATE_TIME);
     }
 
     // large objects
@@ -275,7 +294,7 @@ public final class JDBCStatementHelper {
       // sql timestamp
       if (DATETIME.matcher(value).matches()) {
         Instant instant = Instant.from(ISO_INSTANT.parse(value));
-        return new Timestamp(instant.toEpochMilli());
+        return Timestamp.from(instant);
       }
 
       // sql uuid

--- a/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
@@ -1,29 +1,44 @@
 package io.vertx.ext.jdbc.impl.actions;
 
+import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
+import static java.time.format.DateTimeFormatter.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class SQLConvertTest {
 
-  private JDBCStatementHelper helper = new JDBCStatementHelper();
+  private JsonObject config = new JsonObject().put("castUUID", true);
 
-  @Parameterized.Parameters
+  private JDBCStatementHelper helper = new JDBCStatementHelper(config);
+
+  @Parameters(name = "{0}")
   public static Collection<Object[]> generateData() {
-    return Arrays.asList(new Object[][] {
-        // simple types
-        {"16:00:00"},
-        {"2016-03-16"},
-        {"2016-03-16T16:00:00Z"},
-        {"f47ac10b-58cc-4372-a567-0e02b2c3d479"},
-    });
+    List<Object[]> params = new ArrayList<>();
+
+    ZonedDateTime dateTime = ZonedDateTime.of(2016, 3, 16, 16, 0, 0, 0, ZoneId.of("Europe/Paris"));
+    for (int i = 0; i < 4; i++) {
+      int nanos = 123 * (i == 0 ? 0 : 1) * (int) Math.pow(1000, i > 1 ? i - 1 : 0);
+      params.add(new Object[]{ISO_INSTANT.format(dateTime.withNano(nanos))});
+    }
+    params.add(new Object[]{ISO_LOCAL_TIME.format(dateTime.withSecond(1))});
+    params.add(new Object[]{dateTime.toLocalDate().toString()});
+
+    params.add(new Object[]{"f47ac10b-58cc-4372-a567-0e02b2c3d479"});
+
+    return params;
   }
 
   // Fields
@@ -36,8 +51,9 @@ public class SQLConvertTest {
   @Test
   public void testSQLConvert() throws SQLException {
     Object cast = helper.optimisticCast(value);
-    Object convert = helper.convertSqlValue(cast);
+    assertThat(cast, not(instanceOf(String.class)));
 
+    Object convert = JDBCStatementHelper.convertSqlValue(cast);
     assertEquals(value, convert);
   }
 }

--- a/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
@@ -12,6 +12,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 import static java.time.format.DateTimeFormatter.*;
 import static org.hamcrest.CoreMatchers.*;
@@ -31,27 +32,28 @@ public class SQLConvertTest {
     ZonedDateTime dateTime = ZonedDateTime.of(2016, 3, 16, 16, 0, 0, 0, ZoneId.of("Europe/Paris"));
     for (int i = 0; i < 4; i++) {
       int nanos = 123 * (i == 0 ? 0 : 1) * (int) Math.pow(1000, i > 1 ? i - 1 : 0);
-      params.add(new Object[]{ISO_INSTANT.format(dateTime.withNano(nanos))});
+      params.add(new Object[]{ISO_INSTANT.format(dateTime.withNano(nanos)), java.sql.Timestamp.class});
     }
-    params.add(new Object[]{ISO_LOCAL_TIME.format(dateTime.withSecond(1))});
-    params.add(new Object[]{dateTime.toLocalDate().toString()});
+    params.add(new Object[]{ISO_LOCAL_TIME.format(dateTime.withSecond(1)), java.sql.Time.class});
+    params.add(new Object[]{dateTime.toLocalDate().toString(), java.sql.Date.class});
 
-    params.add(new Object[]{"f47ac10b-58cc-4372-a567-0e02b2c3d479"});
+    params.add(new Object[]{"f47ac10b-58cc-4372-a567-0e02b2c3d479", UUID.class});
 
     return params;
   }
 
-  // Fields
   private String value;
+  private Class<?> expectedSqlType;
 
-  public SQLConvertTest(String value) {
+  public SQLConvertTest(String value, Class<?> expectedSqlType) {
     this.value = value;
+    this.expectedSqlType = expectedSqlType;
   }
 
   @Test
   public void testSQLConvert() throws SQLException {
     Object cast = helper.optimisticCast(value);
-    assertThat(cast, not(instanceOf(String.class)));
+    assertThat(cast, instanceOf(expectedSqlType));
 
     Object convert = JDBCStatementHelper.convertSqlValue(cast);
     assertEquals(value, convert);


### PR DESCRIPTION
An Instant may carry submillisecond data. So when it is added to Json, this information is reflected in the String conversion.
But the current regular expression in JDBCStatementHelper only allows for milliseconds precision.
Consequently, the value is not even identified as a timestamp, but as a String.

In addition to that, the current from/to SQL conversion methods simply erase submillisecond data, even though it's supported in the java.sql.Timestamp format.

SQLConvertTest has been updated with more test cases. Also it's been fixed because if something wasn't properly detected, it was simply returned as String and of course was equal to the original.