### PR TITLE
RowStream accumulator

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -163,6 +163,8 @@ The following configuration properties generally apply:
 `provider_class`:: The class name of the class actually used to manage the database connections. By default this is
 `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider` but if you want to use a different provider you can override
 this property and provide your implementation.
+`row_stream_fetch_size`:: The size of `SQLRowStream` internal cache which used to better performance. By default
+it equals to `128`
 
 Assuming the C3P0 implementation is being used (the default), the following extra configuration properties apply:
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -145,6 +145,8 @@ The following configuration properties generally apply:
 `provider_class`:: The class name of the class actually used to manage the database connections. By default this is
 `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider` but if you want to use a different provider you can override
 this property and provide your implementation.
+`row_stream_fetch_size`:: The size of `SQLRowStream` internal cache which used to better performance. By default
+it equals to `128`
 
 Assuming the C3P0 implementation is being used (the default), the following extra configuration properties apply:
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -167,6 +167,8 @@ The following configuration properties generally apply:
 `provider_class`:: The class name of the class actually used to manage the database connections. By default this is
 `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider` but if you want to use a different provider you can override
 this property and provide your implementation.
+`row_stream_fetch_size`:: The size of `SQLRowStream` internal cache which used to better performance. By default
+it equals to `128`
 
 Assuming the C3P0 implementation is being used (the default), the following extra configuration properties apply:
 

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -163,6 +163,8 @@ The following configuration properties generally apply:
 `provider_class`:: The class name of the class actually used to manage the database connections. By default this is
 `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider` but if you want to use a different provider you can override
 this property and provide your implementation.
+`row_stream_fetch_size`:: The size of `SQLRowStream` internal cache which used to better performance. By default
+it equals to `128`
 
 Assuming the C3P0 implementation is being used (the default), the following extra configuration properties apply:
 

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -167,6 +167,8 @@ The following configuration properties generally apply:
 `provider_class`:: The class name of the class actually used to manage the database connections. By default this is
 `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider` but if you want to use a different provider you can override
 this property and provide your implementation.
+`row_stream_fetch_size`:: The size of `SQLRowStream` internal cache which used to better performance. By default
+it equals to `128`
 
 Assuming the C3P0 implementation is being used (the default), the following extra configuration properties apply:
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
@@ -41,17 +41,19 @@ class JDBCConnectionImpl implements SQLConnection {
   private final WorkerExecutor executor;
   private final PoolMetrics metrics;
   private final Object metric;
+  private final int rowStreamFetchSize;
 
   private final JDBCStatementHelper helper;
 
   private int timeout = -1;
 
-  public JDBCConnectionImpl(Context context, JDBCStatementHelper helper, Connection conn, PoolMetrics metrics, Object metric) {
+  public JDBCConnectionImpl(Context context, JDBCStatementHelper helper, Connection conn, PoolMetrics metrics, Object metric, int rowStreamFetchSize) {
     this.vertx = context.owner();
     this.helper = helper;
     this.conn = conn;
     this.metrics = metrics;
     this.metric = metric;
+    this.rowStreamFetchSize = rowStreamFetchSize;
     this.executor = ((ContextInternal)context).createWorkerExecutor();
   }
 
@@ -75,13 +77,13 @@ class JDBCConnectionImpl implements SQLConnection {
 
   @Override
   public SQLConnection queryStream(String sql, Handler<AsyncResult<SQLRowStream>> handler) {
-    new StreamQuery(vertx, helper, conn, executor, timeout, sql, null).execute(handler);
+    new StreamQuery(vertx, helper, conn, executor, timeout, rowStreamFetchSize, sql, null).execute(handler);
     return this;
   }
 
   @Override
   public SQLConnection queryStreamWithParams(String sql, JsonArray params, Handler<AsyncResult<SQLRowStream>> handler) {
-    new StreamQuery(vertx, helper, conn, executor, timeout, sql, params).execute(handler);
+    new StreamQuery(vertx, helper, conn, executor, timeout, rowStreamFetchSize, sql, params).execute(handler);
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
@@ -34,12 +34,14 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
   private final String sql;
   private final JsonArray in;
   private final int timeout;
+  private final int rowStreamFetchSize;
 
-  public StreamQuery(Vertx vertx, JDBCStatementHelper helper, Connection connection, WorkerExecutor exec, int timeout, String sql, JsonArray in) {
+  public StreamQuery(Vertx vertx, JDBCStatementHelper helper, Connection connection, WorkerExecutor exec, int timeout, int rowStreamFetchSize, String sql, JsonArray in) {
     super(vertx, helper, connection, exec);
     this.sql = sql;
     this.in = in;
     this.timeout = timeout;
+    this.rowStreamFetchSize = rowStreamFetchSize;
   }
 
   @Override
@@ -58,7 +60,7 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
 
       try {
         rs = st.executeQuery();
-        return new JDBCSQLRowStream(exec, st, rs);
+        return new JDBCSQLRowStream(exec, st, rs, rowStreamFetchSize);
       } catch (SQLException e) {
         if (rs != null) {
           rs.close();

--- a/src/main/java/io/vertx/ext/jdbc/package-info.java
+++ b/src/main/java/io/vertx/ext/jdbc/package-info.java
@@ -146,6 +146,8 @@
  * `provider_class`:: The class name of the class actually used to manage the database connections. By default this is
  * `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider` but if you want to use a different provider you can override
  * this property and provide your implementation.
+ * `row_stream_fetch_size`:: The size of `SQLRowStream` internal cache which used to better performance. By default
+ * it equals to `128`
  *
  * Assuming the C3P0 implementation is being used (the default), the following extra configuration properties apply:
  *

--- a/src/test/java/io/vertx/ext/jdbc/JDBCClientTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCClientTest.java
@@ -163,6 +163,26 @@ public class JDBCClientTest extends JDBCClientTestBase {
   }
 
   @Test
+  public void testBigStream() {
+    String sql = "SELECT * FROM big_table";
+    final AtomicInteger cnt = new AtomicInteger(0);
+    connection().queryStream(sql, onSuccess(res -> {
+      res.resultSetClosedHandler(v -> {
+        res.moreResults();
+      }).handler(row -> {
+        cnt.incrementAndGet();
+      }).endHandler(v -> {
+        assertEquals(200, cnt.get());
+        testComplete();
+      }).exceptionHandler(t -> {
+        fail(t);
+      });
+    }));
+
+    await();
+  }
+
+  @Test
   public void testStreamColumnResolution() {
     String sql = "SELECT ID, FNAME, LNAME FROM select_table ORDER BY ID";
     final AtomicInteger cnt = new AtomicInteger(0);

--- a/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
@@ -56,6 +56,10 @@ public abstract class JDBCClientTestBase extends VertxTestBase {
     SQL.add("insert into delete_table values (2, 'doe', 'jane', '2002-02-02');");
     SQL.add("create table blob_table (b blob, c clob, a int array default array[]);");
     SQL.add("insert into blob_table (b, c, a) values (load_file('pom.xml'), convert('Hello', clob),  ARRAY[1,2,3])");
+    SQL.add("create table big_table(id int primary key, name varchar(255))");
+    for (int i = 0; i < 200; i++) {
+      SQL.add("insert into big_table values(" + i + ", 'Hello')");
+    }
   }
 
   @BeforeClass


### PR DESCRIPTION
In current `SQLRowStream` implementation every row fetched in own `worker.executeBlocking()` method. This patch introduces internal accumulator to read batch of rows in one time. On my computer fetching of 2M rows runs 10x faster. All tests (including pause/resume) passes.

@pmlopes please review