### PR TITLE
Changes to support naming of generated keys when performing update.

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
@@ -97,13 +97,19 @@ class JDBCConnectionImpl implements SQLConnection {
 
   @Override
   public SQLConnection update(String sql, Handler<AsyncResult<UpdateResult>> resultHandler) {
-    new JDBCUpdate(vertx, helper, conn, ctx, statementsQueue, timeout, sql, null).execute(resultHandler);
+    new JDBCUpdate(vertx, helper, conn, ctx, statementsQueue, timeout, sql, null, null).execute(resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection updateWithParams(String sql, JsonArray params, Handler<AsyncResult<UpdateResult>> resultHandler) {
-    new JDBCUpdate(vertx, helper, conn, ctx, statementsQueue, timeout, sql, params).execute(resultHandler);
+    new JDBCUpdate(vertx, helper, conn, ctx, statementsQueue, timeout, sql, params, null).execute(resultHandler);
+    return this;
+  }
+
+  @Override
+  public SQLConnection updateWithParams(String sql, JsonArray params, List<String> columnNames, Handler<AsyncResult<UpdateResult>> resultHandler) {
+    new JDBCUpdate(vertx, helper, conn, ctx, statementsQueue, timeout, sql, params, columnNames).execute(resultHandler);
     return this;
   }
 


### PR DESCRIPTION
To summarise, my team is currently using vertx-jdbc-client to interact with an Oracle database.

We are extremely happy with all aspects of your project, but we have found one functional gap which affects us. We are unable to name generated keys when performing an update statement.  This is proving to be an issue for us, since the Oracle driver requires you to explicitly specify the generated key column name when performing an update. If you do not, you get back the row id value, which is useless in our use case.  

Have posted an associated pull request for the change to vertx-sql-common.