### PR TITLE
Common SQLClient interface with implementation

### DIFF
--- a/src/main/java/examples/JDBCExamples.java
+++ b/src/main/java/examples/JDBCExamples.java
@@ -4,6 +4,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;
 import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 
 import javax.sql.DataSource;
@@ -16,26 +17,26 @@ public class JDBCExamples {
 
   public void exampleCreateDefault(Vertx vertx, JsonObject config) {
 
-    JDBCClient client = JDBCClient.createShared(vertx, config);
+    SQLClient client = JDBCClient.createShared(vertx, config);
 
   }
 
   public void exampleCreateDataSourceName(Vertx vertx, JsonObject config) {
 
 
-    JDBCClient client = JDBCClient.createShared(vertx, config, "MyDataSource");
+    SQLClient client = JDBCClient.createShared(vertx, config, "MyDataSource");
 
   }
 
   public void exampleCreateWithDataSource(Vertx vertx, DataSource dataSource) {
 
-    JDBCClient client = JDBCClient.create(vertx, dataSource);
+    SQLClient client = JDBCClient.create(vertx, dataSource);
 
   }
 
   public void exampleCreateNonShared(Vertx vertx, JsonObject config) {
 
-    JDBCClient client = JDBCClient.createNonShared(vertx, config);
+    SQLClient client = JDBCClient.createNonShared(vertx, config);
 
   }
 
@@ -69,7 +70,7 @@ public class JDBCExamples {
       .put("driver_class", "org.hsqldb.jdbcDriver")
       .put("max_pool_size", 30);
 
-    JDBCClient client = JDBCClient.createShared(vertx, config);
+    SQLClient client = JDBCClient.createShared(vertx, config);
 
   }
 }

--- a/src/main/java/io/vertx/ext/jdbc/JDBCClient.java
+++ b/src/main/java/io/vertx/ext/jdbc/JDBCClient.java
@@ -16,15 +16,12 @@
 
 package io.vertx.ext.jdbc;
 
-import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.impl.JDBCClientImpl;
-import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.sql.SQLClient;
 
 import javax.sql.DataSource;
 import java.util.UUID;
@@ -36,7 +33,7 @@ import java.util.UUID;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface JDBCClient {
+public interface JDBCClient extends SQLClient {
 
   /**
    * The default data source provider is C3P0
@@ -55,7 +52,7 @@ public interface JDBCClient {
    * @param config  the configuration
    * @return the client
    */
-  static JDBCClient createNonShared(Vertx vertx, JsonObject config) {
+  static SQLClient createNonShared(Vertx vertx, JsonObject config) {
     return new JDBCClientImpl(vertx, config, UUID.randomUUID().toString());
   }
 
@@ -68,7 +65,7 @@ public interface JDBCClient {
    * @param dataSourceName  the data source name
    * @return the client
    */
-  static JDBCClient createShared(Vertx vertx, JsonObject config, String dataSourceName) {
+  static SQLClient createShared(Vertx vertx, JsonObject config, String dataSourceName) {
     return new JDBCClientImpl(vertx, config, dataSourceName);
   }
 
@@ -78,7 +75,7 @@ public interface JDBCClient {
    * @param config  the configuration
    * @return the client
    */
-  static JDBCClient createShared(Vertx vertx, JsonObject config) {
+  static SQLClient createShared(Vertx vertx, JsonObject config) {
     return new JDBCClientImpl(vertx, config, DEFAULT_DS_NAME);
   }
 
@@ -90,21 +87,7 @@ public interface JDBCClient {
    * @return the client
    */
   @GenIgnore
-  static JDBCClient create(Vertx vertx, DataSource dataSource) {
+  static SQLClient create(Vertx vertx, DataSource dataSource) {
     return new JDBCClientImpl(vertx, dataSource);
   }
-
-  /**
-   * Returns a connection that can be used to perform SQL operations on. It's important to remember
-   * to close the connection when you are done, so it is returned to the pool.
-   *
-   * @param handler the handler which is called when the <code>JdbcConnection</code> object is ready for use.
-   */
-  @Fluent
-  JDBCClient getConnection(Handler<AsyncResult<SQLConnection>> handler);
-
-  /**
-   * Close the client
-   */
-  void close();
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
@@ -25,6 +25,7 @@ import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.ext.jdbc.JDBCClient;
 import io.vertx.ext.jdbc.impl.actions.JDBCStatementHelper;
 import io.vertx.ext.jdbc.spi.DataSourceProvider;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 
 import javax.sql.DataSource;
@@ -109,7 +110,7 @@ public class JDBCClientImpl implements JDBCClient {
   }
 
   @Override
-  public JDBCClient getConnection(Handler<AsyncResult<SQLConnection>> handler) {
+  public SQLClient getConnection(Handler<AsyncResult<SQLConnection>> handler) {
     Context ctx = vertx.getOrCreateContext();
     boolean enabled = metrics != null && metrics.isEnabled();
     Object queueMetric = enabled ? metrics.submitted() : null;

--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
@@ -110,6 +110,11 @@ public class JDBCClientImpl implements JDBCClient {
   }
 
   @Override
+  public void close(Handler<AsyncResult<Void>> completionHandler) {
+    holder.close(completionHandler);
+  }
+
+  @Override
   public SQLClient getConnection(Handler<AsyncResult<SQLConnection>> handler) {
     Context ctx = vertx.getOrCreateContext();
     boolean enabled = metrics != null && metrics.isEnabled();

--- a/src/test/java/io/vertx/ext/jdbc/CloseTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/CloseTest.java
@@ -5,6 +5,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.spi.DataSourceProvider;
 import io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class CloseTest extends JDBCClientTestBase {
   public static class NonSharedClientVerticle extends AbstractVerticle {
     @Override
     public void start(io.vertx.core.Future<Void> f) throws Exception {
-      JDBCClient client = JDBCClient.createNonShared(vertx, theConfig);
+      SQLClient client = JDBCClient.createNonShared(vertx, theConfig);
       String sql = "SELECT ID, FNAME, LNAME FROM select_table ORDER BY ID";
       client.getConnection(ar1 -> {
         if (ar1.succeeded()) {
@@ -64,7 +65,7 @@ public class CloseTest extends JDBCClientTestBase {
   public static class SharedClientVerticle extends AbstractVerticle {
     @Override
     public void start(io.vertx.core.Future<Void> f) throws Exception {
-      JDBCClient client = JDBCClient.createShared(vertx, theConfig);
+      SQLClient client = JDBCClient.createShared(vertx, theConfig);
       String sql = "SELECT ID, FNAME, LNAME FROM select_table ORDER BY ID";
       client.getConnection(ar1 -> {
         if (ar1.succeeded()) {
@@ -102,7 +103,7 @@ public class CloseTest extends JDBCClientTestBase {
   public static class ProvidedDataSourceVerticle extends AbstractVerticle {
     @Override
     public void start(io.vertx.core.Future<Void> f) throws Exception {
-      JDBCClient client = JDBCClient.create(vertx, ds);
+      SQLClient client = JDBCClient.create(vertx, ds);
       String sql = "SELECT ID, FNAME, LNAME FROM select_table ORDER BY ID";
       client.getConnection(ar1 -> {
         if (ar1.succeeded()) {

--- a/src/test/java/io/vertx/ext/jdbc/JDBCBatchTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCBatchTest.java
@@ -18,6 +18,7 @@ package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.After;
@@ -35,7 +36,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class JDBCBatchTest extends VertxTestBase {
 
-  protected JDBCClient client;
+  protected SQLClient client;
 
   public static void proc() {
     System.out.println("Fake Proc called");

--- a/src/test/java/io/vertx/ext/jdbc/JDBCClientTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCClientTest.java
@@ -22,6 +22,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.impl.actions.AbstractJDBCAction;
 import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
 import io.vertx.rx.java.RxHelper;
@@ -46,7 +47,7 @@ import java.util.logging.Level;
  */
 public class JDBCClientTest extends JDBCClientTestBase {
 
-  protected JDBCClient client;
+  protected SQLClient client;
 
   @Before
   public void setUp() throws Exception {
@@ -58,6 +59,18 @@ public class JDBCClientTest extends JDBCClientTestBase {
   public void after() throws Exception {
     client.close();
     super.after();
+  }
+
+  @Test
+  public void testSqlClientInstance() {
+    assertTrue(client instanceof SQLClient);
+    testComplete();
+  }
+
+  @Test
+  public void testJdbcClientInstance() {
+    assertTrue(client instanceof JDBCClient);
+    testComplete();
   }
 
   @Test

--- a/src/test/java/io/vertx/ext/jdbc/JDBCCustomTXIsolationTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCCustomTXIsolationTest.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.After;
@@ -31,7 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class JDBCCustomTXIsolationTest extends VertxTestBase {
 
-  protected JDBCClient client;
+  protected SQLClient client;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/io/vertx/ext/jdbc/JDBCCustomTypesTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCCustomTypesTest.java
@@ -18,6 +18,7 @@ package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.After;
@@ -48,7 +49,7 @@ public class JDBCCustomTypesTest extends VertxTestBase {
   }
 
   private JsonObject config;
-  private JDBCClient client;
+  private SQLClient client;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/io/vertx/ext/jdbc/JDBCPoolMetricsTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCPoolMetricsTest.java
@@ -7,6 +7,7 @@ import io.vertx.core.metrics.impl.DummyVertxMetrics;
 import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakemetrics.FakePoolMetrics;
 import org.junit.Test;
@@ -25,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class JDBCPoolMetricsTest extends VertxTestBase {
 
-  private JDBCClient client;
+  private SQLClient client;
   private FakePoolMetrics metrics;
 
   public void after() throws Exception {
@@ -35,7 +36,7 @@ public class JDBCPoolMetricsTest extends VertxTestBase {
     super.after();
   }
 
-  private JDBCClient getClient() {
+  private SQLClient getClient() {
     if (client == null) {
       Map<String, PoolMetrics> metricsMap = FakePoolMetrics.getPoolMetrics();
       Set<String> keys = new HashSet<>(metricsMap.keySet());

--- a/src/test/java/io/vertx/ext/jdbc/JDBCQueryTimeoutTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCQueryTimeoutTest.java
@@ -17,18 +17,13 @@
 package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.test.core.VertxTestBase;
-import org.hsqldb.jdbc.JDBCConnection;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -37,7 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class JDBCQueryTimeoutTest extends VertxTestBase {
 
-  protected JDBCClient client;
+  protected SQLClient client;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/io/vertx/ext/jdbc/JDBCStoredProcedure2Test.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCStoredProcedure2Test.java
@@ -18,9 +18,13 @@ package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.test.core.VertxTestBase;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,7 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class JDBCStoredProcedure2Test extends VertxTestBase {
 
-  protected JDBCClient client;
+  protected SQLClient client;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/io/vertx/ext/jdbc/JDBCStoredProcedureTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCStoredProcedureTest.java
@@ -18,6 +18,7 @@ package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.After;
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class JDBCStoredProcedureTest extends VertxTestBase {
 
-  protected JDBCClient client;
+  protected SQLClient client;
 
   private static final List<String> SQL = new ArrayList<>();
 

--- a/src/test/java/io/vertx/ext/jdbc/JDBCTypesTestBase.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCTypesTestBase.java
@@ -18,6 +18,7 @@ package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
 import io.vertx.test.core.VertxTestBase;
@@ -40,7 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class JDBCTypesTestBase extends VertxTestBase {
 
-  protected JDBCClient client;
+  protected SQLClient client;
 
   private static final List<String> SQL = new ArrayList<>();
 

--- a/src/test/java/io/vertx/ext/jdbc/RefCountTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/RefCountTest.java
@@ -2,6 +2,7 @@ package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.LocalMap;
+import io.vertx.ext.sql.SQLClient;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -19,11 +20,11 @@ public class RefCountTest extends VertxTestBase {
     LocalMap<String, Object> map = getLocalMap();
     JsonObject config = new JsonObject();
     config.put("provider_class", TestDSProvider.class.getName());
-    JDBCClient client1 = JDBCClient.createNonShared(vertx, config);
+    SQLClient client1 = JDBCClient.createNonShared(vertx, config);
     assertEquals(1, TestDSProvider.instanceCount.get());
-    JDBCClient client2 = JDBCClient.createNonShared(vertx, config);
+    SQLClient client2 = JDBCClient.createNonShared(vertx, config);
     assertEquals(2, TestDSProvider.instanceCount.get());
-    JDBCClient client3 = JDBCClient.createNonShared(vertx, config);
+    SQLClient client3 = JDBCClient.createNonShared(vertx, config);
     assertEquals(3, TestDSProvider.instanceCount.get());
     client1.close();
     assertWaitUntil(() -> TestDSProvider.instanceCount.get() == 2);
@@ -40,13 +41,13 @@ public class RefCountTest extends VertxTestBase {
     LocalMap<String, Object> map = getLocalMap();
     JsonObject config = new JsonObject();
     config.put("provider_class", TestDSProvider.class.getName());
-    JDBCClient client1 = JDBCClient.createShared(vertx, config);
+    SQLClient client1 = JDBCClient.createShared(vertx, config);
     assertEquals(1, TestDSProvider.instanceCount.get());
     assertEquals(1, map.size());
-    JDBCClient client2 = JDBCClient.createShared(vertx, config);
+    SQLClient client2 = JDBCClient.createShared(vertx, config);
     assertEquals(1, TestDSProvider.instanceCount.get());
     assertEquals(1, map.size());
-    JDBCClient client3 = JDBCClient.createShared(vertx, config);
+    SQLClient client3 = JDBCClient.createShared(vertx, config);
     assertEquals(1, TestDSProvider.instanceCount.get());
     assertEquals(1, map.size());
     client1.close();
@@ -67,23 +68,23 @@ public class RefCountTest extends VertxTestBase {
     LocalMap<String, Object> map = getLocalMap();
     JsonObject config = new JsonObject();
     config.put("provider_class", TestDSProvider.class.getName());
-    JDBCClient client1 = JDBCClient.createShared(vertx, config, "ds1");
+    SQLClient client1 = JDBCClient.createShared(vertx, config, "ds1");
     assertEquals(1, TestDSProvider.instanceCount.get());
     assertEquals(1, map.size());
-    JDBCClient client2 = JDBCClient.createShared(vertx, config, "ds1");
+    SQLClient client2 = JDBCClient.createShared(vertx, config, "ds1");
     assertEquals(1, TestDSProvider.instanceCount.get());
     assertEquals(1, map.size());
-    JDBCClient client3 = JDBCClient.createShared(vertx, config, "ds1");
+    SQLClient client3 = JDBCClient.createShared(vertx, config, "ds1");
     assertEquals(1, TestDSProvider.instanceCount.get());
     assertEquals(1, map.size());
 
-    JDBCClient client4 = JDBCClient.createShared(vertx, config, "ds2");
+    SQLClient client4 = JDBCClient.createShared(vertx, config, "ds2");
     assertEquals(2, TestDSProvider.instanceCount.get());
     assertEquals(2, map.size());
-    JDBCClient client5 = JDBCClient.createShared(vertx, config, "ds2");
+    SQLClient client5 = JDBCClient.createShared(vertx, config, "ds2");
     assertEquals(2, TestDSProvider.instanceCount.get());
     assertEquals(2, map.size());
-    JDBCClient client6 = JDBCClient.createShared(vertx, config, "ds2");
+    SQLClient client6 = JDBCClient.createShared(vertx, config, "ds2");
     assertEquals(2, TestDSProvider.instanceCount.get());
     assertEquals(2, map.size());
 

--- a/src/test/java/io/vertx/ext/jdbc/SharedClientTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/SharedClientTest.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.jdbc;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -25,7 +26,7 @@ public class SharedClientTest extends JDBCClientTestBase {
         public void run() {
           for (int i = 0;i < iter;i++) {
             count.incrementAndGet();
-            JDBCClient client = JDBCClient.createShared(vertx, config);
+            SQLClient client = JDBCClient.createShared(vertx, config);
             client.close();
           }
         }


### PR DESCRIPTION
This PR will share client interface `SQLClient` as same as `SQLConnection` derived from common interfaces in this PR [#46](https://github.com/vert-x3/vertx-sql-common/pull/46) I think this will be major change.

