### PR TITLE
Update C3P0DataSourceProvider.java

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/spi/impl/C3P0DataSourceProvider.java
+++ b/src/main/java/io/vertx/ext/jdbc/spi/impl/C3P0DataSourceProvider.java
@@ -44,6 +44,9 @@ public class C3P0DataSourceProvider implements DataSourceProvider {
     Integer maxStatements = config.getInteger("max_statements");
     Integer maxStatementsPerConnection = config.getInteger("max_statements_per_connection");
     Integer maxIdleTime = config.getInteger("max_idle_time");
+    Integer acquireRetryAttempts = config.getInteger("acquire_retry_attempts");
+    Integer acquireRetryDelay = config.getInteger("acquire_retry_delay");
+    Boolean breakAfterAcquireFailure = config.getBoolean("break_after_acquire_failure");
 
     // If you want to configure any other C3P0 properties you can add a file c3p0.properties to the classpath
     ComboPooledDataSource cpds = new ComboPooledDataSource();
@@ -78,6 +81,15 @@ public class C3P0DataSourceProvider implements DataSourceProvider {
     }
     if (maxIdleTime != null) {
       cpds.setMaxIdleTime(maxIdleTime);
+    }
+    if(acquireRetryAttempts != null){
+      cpds.setAcquireRetryAttempts(acquireRetryAttempts);
+    }
+    if(acquireRetryDelay != null){
+      cpds.setAcquireRetryDelay(acquireRetryDelay);
+    }
+    if(breakAfterAcquireFailure != null){
+      cpds.setBreakAfterAcquireFailure(breakAfterAcquireFailure);
     }
     return cpds;
   }


### PR DESCRIPTION
Add additional entries in configuration for
+ acquire_retry_attempts
+ acquire_retry_delay
+break_after_acquire_failure
in order to enable fast of a database is available during startup of a verticle and more resilient operations during service provision.

There is a unit-testcase
[C3P0Test.zip](https://github.com/vert-x3/vertx-jdbc-client/files/1575518/C3P0Test.zip)
