### PR TITLE
Deprecate BoneCP

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -148,7 +148,7 @@ Assuming the C3P0 implementation is being used (the default), the following extr
 
 Other Connection Pool providers are:
 
-* BoneCP
+* BoneCP (**DEPRECATED** you should avoid this pool as it has been deprecated upstream)
 * Hikari
 
 Similar to C3P0 they can be configured by passing the configuration values on the JSON config object. For the special

--- a/src/main/java/io/vertx/ext/jdbc/spi/impl/BoneCPDataSourceProvider.java
+++ b/src/main/java/io/vertx/ext/jdbc/spi/impl/BoneCPDataSourceProvider.java
@@ -30,7 +30,9 @@ import java.util.Map;
 
 /**
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
+ * @deprecated BoneCP has been deprecated upstream, please use other Connection Pool
  */
+@Deprecated
 public class BoneCPDataSourceProvider implements DataSourceProvider {
 
   private static final Logger log = LoggerFactory.getLogger(BoneCPDataSourceProvider.class);


### PR DESCRIPTION
BoneCP has been deprecated upstream, this PR deprecates it in this module so we will perform cleanup on the next major release.