### PR TITLE
Use column labels instead of column names for SQLRowStream.columns()

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCSQLRowStream.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCSQLRowStream.java
@@ -104,7 +104,7 @@ class JDBCSQLRowStream implements SQLRowStream {
         if (cols > 0) {
           final List<String> columns = new ArrayList<>(cols);
           for (int i = 0; i < cols; i++) {
-            columns.add(i, metaData.getColumnName(i + 1));
+            columns.add(i, metaData.getColumnLabel(i + 1));
           }
           this.columns = Collections.unmodifiableList(columns);
         } else {


### PR DESCRIPTION
Fixes #147 