### PR TITLE
fix: update c3P0 dependency to v0.9.5.4 to prevent DoS vulnerability. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>0.9.5.2</version>
+      <version>0.9.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
For details, see [release notes of c3p0 v0.9.5.4](https://github.com/swaldman/c3p0/blob/c3p0-0.9.5.4/src/dist-static/RELEASE_NOTES-c3p0-0.9.5.4)

Summary of the fix:

> CVE-2018-20433, https://nvd.nist.gov/vuln/detail/CVE-2018-20433
>     
>   The c3p0 parsed XML config files liberally, including resolving external
>   entity references. Incautious use of this feature could permit injection
>   of malicious config. Now c3p0 does not resolve external entity references
>   in its the XML config file.