### PR TITLE
Address issue #110 - Support for storing binary data

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -206,6 +206,10 @@ a VARCHAR(36) column. For other engines UUID optimistic casting can be enabled u
 
 When this config is present UUIDs will be handled as a native type.
 
+Storing data to a binary column encounters an issue because the internally stored Based64 encoding of the array
+isn't recognized as a byte array. Enable optimistic casting of a Base64-encoded string to a byte[] using:
+
+{ "castBase64": true }
 
 == Use as OSGi bundle
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCStatementHelper.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCStatementHelper.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.impl.logging.Logger;
@@ -41,10 +42,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static java.time.format.DateTimeFormatter.*;
@@ -63,8 +61,10 @@ public final class JDBCStatementHelper {
   private static final Pattern DATE = Pattern.compile("^\\d{4}-(?:0[0-9]|1[0-2])-[0-9]{2}$");
   private static final Pattern TIME = Pattern.compile("^\\d{2}:\\d{2}:\\d{2}$");
   private static final Pattern UUID = Pattern.compile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$");
+  private static final Pattern BASE64 = Pattern.compile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)$");
 
   private final boolean castUUID;
+  private final boolean castBase64;
 
   public JDBCStatementHelper() {
     this(new JsonObject());
@@ -72,6 +72,7 @@ public final class JDBCStatementHelper {
 
   public JDBCStatementHelper(JsonObject config) {
     this.castUUID = config.getBoolean("castUUID", false);
+    this.castBase64 = config.getBoolean("castBase64", false);
   }
 
   public void fillStatement(PreparedStatement statement, JsonArray in) throws SQLException {
@@ -300,6 +301,11 @@ public final class JDBCStatementHelper {
       // sql uuid
       if (castUUID && UUID.matcher(value).matches()) {
         return java.util.UUID.fromString(value);
+      }
+
+      // possible byte[]
+      if (castBase64 && BASE64.matcher(value).matches()) {
+        return Base64.getDecoder().decode(value);
       }
 
     } catch (RuntimeException e) {

--- a/src/test/java/io/vertx/ext/jdbc/impl/actions/OptimisticCastTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/impl/actions/OptimisticCastTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class OptimisticCastTest {
 
-  private JDBCStatementHelper helper = new JDBCStatementHelper(new JsonObject().put("castUUID", true));
+  private JDBCStatementHelper helper = new JDBCStatementHelper(new JsonObject().put("castUUID", true).put("castBase64", true));
 
   @Parameterized.Parameters
   public static Collection<Object[]> generateData() {
@@ -23,6 +23,7 @@ public class OptimisticCastTest {
         {"2016-03-16", "java.sql.Date"},
         {"2016-03-16T16:00:00Z", "java.sql.Timestamp"},
         {"f47ac10b-58cc-4372-a567-0e02b2c3d479", "java.util.UUID"},
+        {"Dyu+lY5vAxJhM8UCCOtk7w==", "[B"},
         // bad variations
         {"2016-03-16T16:00:00", "java.lang.String"},
         {"24:00:00", "java.lang.String"},

--- a/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/impl/actions/SQLConvertTest.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.jdbc.impl.actions;
 
+import com.mysql.cj.core.util.Base64Decoder;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,10 +10,7 @@ import org.junit.runners.Parameterized.Parameters;
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static java.time.format.DateTimeFormatter.*;
 import static org.hamcrest.CoreMatchers.*;
@@ -21,7 +19,7 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class SQLConvertTest {
 
-  private JsonObject config = new JsonObject().put("castUUID", true);
+  private JsonObject config = new JsonObject().put("castUUID", true).put("castBase64", true);
 
   private JDBCStatementHelper helper = new JDBCStatementHelper(config);
 
@@ -38,6 +36,7 @@ public class SQLConvertTest {
     params.add(new Object[]{dateTime.toLocalDate().toString(), java.sql.Date.class});
 
     params.add(new Object[]{"f47ac10b-58cc-4372-a567-0e02b2c3d479", UUID.class});
+    params.add(new Object[]{"Dyu+lY5vAxJhM8UCCOtk7w==", byte[].class});
 
     return params;
   }
@@ -56,6 +55,10 @@ public class SQLConvertTest {
     assertThat(cast, instanceOf(expectedSqlType));
 
     Object convert = JDBCStatementHelper.convertSqlValue(cast);
-    assertEquals(value, convert);
+    if ( convert instanceof byte[] ) {
+      assertArrayEquals(Base64.getDecoder().decode(value), (byte[])convert);
+    } else {
+      assertEquals(value, convert);
+    }
   }
 }


### PR DESCRIPTION
This change follows the pattern established in JDBCStatementHelper that uses a regex accommodate data types not directly supported by JSON.

The Base64 regex was sourced from https://www.npmjs.com/package/base64-regex .