### PR TITLE
Refactored JDBC action scheduling

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
@@ -144,28 +144,28 @@ public class JDBCClientImpl implements JDBCClient {
   @Override
   public JDBCClient update(String sql, Handler<AsyncResult<UpdateResult>> resultHandler) {
     ContextInternal ctx = vertx.getOrCreateContext();
-    executeDirect(ctx, new JDBCUpdate(vertx, helper, null, ctx, sql, null), resultHandler);
+    executeDirect(ctx, new JDBCUpdate(helper, null, ctx, sql, null), resultHandler);
     return this;
   }
 
   @Override
   public JDBCClient updateWithParams(String sql, JsonArray in, Handler<AsyncResult<UpdateResult>> resultHandler) {
     ContextInternal ctx = vertx.getOrCreateContext();
-    executeDirect(ctx, new JDBCUpdate(vertx, helper, null, ctx, sql, in), resultHandler);
+    executeDirect(ctx, new JDBCUpdate(helper, null, ctx, sql, in), resultHandler);
     return this;
   }
 
   @Override
   public JDBCClient query(String sql, Handler<AsyncResult<ResultSet>> resultHandler) {
     ContextInternal ctx = vertx.getOrCreateContext();
-    executeDirect(ctx, new JDBCQuery(vertx, helper, null, ctx, sql, null), resultHandler);
+    executeDirect(ctx, new JDBCQuery(helper, null, ctx, sql, null), resultHandler);
     return this;
   }
 
   @Override
   public JDBCClient queryWithParams(String sql, JsonArray in, Handler<AsyncResult<ResultSet>> resultHandler) {
     ContextInternal ctx = vertx.getOrCreateContext();
-    executeDirect(ctx, new JDBCQuery(vertx, helper, null, ctx, sql, in), resultHandler);
+    executeDirect(ctx, new JDBCQuery(helper, null, ctx, sql, in), resultHandler);
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
@@ -66,67 +66,67 @@ class JDBCConnectionImpl implements SQLConnection {
 
   @Override
   public SQLConnection setAutoCommit(boolean autoCommit, Handler<AsyncResult<Void>> resultHandler) {
-    new JDBCAutoCommit(vertx, options, ctx, autoCommit).execute(conn, statementsQueue, resultHandler);
+    new JDBCAutoCommit(options, ctx, autoCommit).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection execute(String sql, Handler<AsyncResult<Void>> resultHandler) {
-    new JDBCExecute(vertx, options, ctx, sql).execute(conn, statementsQueue, resultHandler);
+    new JDBCExecute(options, ctx, sql).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection query(String sql, Handler<AsyncResult<ResultSet>> resultHandler) {
-    new JDBCQuery(vertx, helper, options, ctx, sql, null).execute(conn, statementsQueue, resultHandler);
+    new JDBCQuery(helper, options, ctx, sql, null).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection queryStream(String sql, Handler<AsyncResult<SQLRowStream>> handler) {
-    new StreamQuery(vertx, helper, options, ctx, statementsQueue, sql, null).execute(conn, statementsQueue,  handler);
+    new StreamQuery(helper, options, ctx, statementsQueue, sql, null).execute(conn, statementsQueue, handler);
     return this;
   }
 
   @Override
   public SQLConnection queryStreamWithParams(String sql, JsonArray params, Handler<AsyncResult<SQLRowStream>> handler) {
-    new StreamQuery(vertx, helper, options, ctx, statementsQueue, sql, params).execute(conn, statementsQueue,  handler);
+    new StreamQuery(helper, options, ctx, statementsQueue, sql, params).execute(conn, statementsQueue, handler);
     return this;
   }
 
   @Override
   public SQLConnection queryWithParams(String sql, JsonArray params, Handler<AsyncResult<ResultSet>> resultHandler) {
-    new JDBCQuery(vertx, helper, options, ctx, sql, params).execute(conn, statementsQueue, resultHandler);
+    new JDBCQuery(helper, options, ctx, sql, params).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection update(String sql, Handler<AsyncResult<UpdateResult>> resultHandler) {
-    new JDBCUpdate(vertx, helper, options, ctx, sql, null).execute(conn, statementsQueue, resultHandler);
+    new JDBCUpdate(helper, options, ctx, sql, null).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection updateWithParams(String sql, JsonArray params, Handler<AsyncResult<UpdateResult>> resultHandler) {
-    new JDBCUpdate(vertx, helper, options, ctx, sql, params).execute(conn, statementsQueue, resultHandler);
+    new JDBCUpdate(helper, options, ctx, sql, params).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection call(String sql, Handler<AsyncResult<ResultSet>> resultHandler) {
-    new JDBCCallable(vertx, helper, options, ctx, sql, null, null).execute(conn, statementsQueue, resultHandler);
+    new JDBCCallable(helper, options, ctx, sql, null, null).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public SQLConnection callWithParams(String sql, JsonArray params, JsonArray outputs, Handler<AsyncResult<ResultSet>> resultHandler) {
-    new JDBCCallable(vertx, helper, options, ctx, sql, params, outputs).execute(conn, statementsQueue, resultHandler);
+    new JDBCCallable(helper, options, ctx, sql, params, outputs).execute(conn, statementsQueue, resultHandler);
     return this;
   }
 
   @Override
   public void close(Handler<AsyncResult<Void>> handler) {
-    new JDBCClose(vertx, options, ctx, metrics, metric).execute(conn, statementsQueue, handler);
+    new JDBCClose(options, ctx, metrics, metric).execute(conn, statementsQueue, handler);
   }
 
   @Override
@@ -140,13 +140,13 @@ class JDBCConnectionImpl implements SQLConnection {
 
   @Override
   public SQLConnection commit(Handler<AsyncResult<Void>> handler) {
-    new JDBCCommit(vertx, options, ctx).execute(conn, statementsQueue,  handler);
+    new JDBCCommit(options, ctx).execute(conn, statementsQueue, handler);
     return this;
   }
 
   @Override
   public SQLConnection rollback(Handler<AsyncResult<Void>> handler) {
-    new JDBCRollback(vertx, options, ctx).execute(conn, statementsQueue,  handler);
+    new JDBCRollback(options, ctx).execute(conn, statementsQueue, handler);
     return this;
   }
 
@@ -171,19 +171,19 @@ class JDBCConnectionImpl implements SQLConnection {
 
   @Override
   public SQLConnection batch(List<String> sqlStatements, Handler<AsyncResult<List<Integer>>> handler) {
-    new JDBCBatch(vertx, helper, options, ctx, sqlStatements).execute(conn, statementsQueue,  handler);
+    new JDBCBatch(helper, options, ctx, sqlStatements).execute(conn, statementsQueue, handler);
     return this;
   }
 
   @Override
   public SQLConnection batchWithParams(String statement, List<JsonArray> args, Handler<AsyncResult<List<Integer>>> handler) {
-    new JDBCBatch(vertx, helper, options, ctx, statement, args).execute(conn, statementsQueue,  handler);
+    new JDBCBatch(helper, options, ctx, statement, args).execute(conn, statementsQueue, handler);
     return this;
   }
 
   @Override
   public SQLConnection batchCallableWithParams(String statement, List<JsonArray> inArgs, List<JsonArray> outArgs, Handler<AsyncResult<List<Integer>>> handler) {
-    new JDBCBatch(vertx, helper, options, ctx, statement, inArgs, outArgs).execute(conn, statementsQueue,  handler);
+    new JDBCBatch(helper, options, ctx, statement, inArgs, outArgs).execute(conn, statementsQueue, handler);
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/AbstractJDBCAction.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/AbstractJDBCAction.java
@@ -17,10 +17,8 @@
 package io.vertx.ext.jdbc.impl.actions;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.TaskQueue;
 import io.vertx.ext.sql.SQLOptions;
@@ -35,17 +33,15 @@ import java.sql.Statement;
  */
 public abstract class AbstractJDBCAction<T> {
 
-  protected final Vertx vertx;
   protected final SQLOptions options;
   protected final ContextInternal ctx;
   protected final JDBCStatementHelper helper;
 
-  protected AbstractJDBCAction(Vertx vertx, SQLOptions options, ContextInternal ctx) {
-    this(vertx, null, options, ctx);
+  protected AbstractJDBCAction(SQLOptions options, ContextInternal ctx) {
+    this(null, options, ctx);
   }
 
-  protected AbstractJDBCAction(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx) {
-    this.vertx = vertx;
+  protected AbstractJDBCAction(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx) {
     this.options = options;
     this.ctx = ctx;
     this.helper = helper;

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/AbstractJDBCAction.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/AbstractJDBCAction.java
@@ -65,8 +65,6 @@ public abstract class AbstractJDBCAction<T> {
 
   public abstract T execute(Connection conn) throws SQLException;
 
-  protected abstract String name();
-
   void applyStatementOptions(Statement statement) throws SQLException {
     if (options != null) {
       if (options.getQueryTimeout() > 0) {

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/AbstractJDBCAction.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/AbstractJDBCAction.java
@@ -16,11 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.TaskQueue;
 import io.vertx.ext.sql.SQLOptions;
 
 import java.sql.Connection;
@@ -34,38 +29,20 @@ import java.sql.Statement;
 public abstract class AbstractJDBCAction<T> {
 
   protected final SQLOptions options;
-  protected final ContextInternal ctx;
   protected final JDBCStatementHelper helper;
 
-  protected AbstractJDBCAction(SQLOptions options, ContextInternal ctx) {
-    this(null, options, ctx);
+  protected AbstractJDBCAction(SQLOptions options) {
+    this(null, options);
   }
 
-  protected AbstractJDBCAction(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx) {
+  protected AbstractJDBCAction(JDBCStatementHelper helper, SQLOptions options) {
     this.options = options;
-    this.ctx = ctx;
     this.helper = helper;
-  }
-
-  private void handle(Connection conn, Promise<T> future) {
-    try {
-      // apply connection options
-      applyConnectionOptions(conn);
-      // execute
-      T result = execute(conn);
-      future.complete(result);
-    } catch (SQLException e) {
-      future.fail(e);
-    }
-  }
-
-  public void execute(Connection conn, TaskQueue statementsQueue, Handler<AsyncResult<T>> resultHandler) {
-    ctx.executeBlocking(future -> handle(conn, future), statementsQueue, resultHandler);
   }
 
   public abstract T execute(Connection conn) throws SQLException;
 
-  void applyStatementOptions(Statement statement) throws SQLException {
+  protected void applyStatementOptions(Statement statement) throws SQLException {
     if (options != null) {
       if (options.getQueryTimeout() > 0) {
         statement.setQueryTimeout(options.getQueryTimeout());
@@ -75,20 +52,6 @@ public abstract class AbstractJDBCAction<T> {
       }
       if (options.getFetchSize() > 0) {
         statement.setFetchSize(options.getFetchSize());
-      }
-    }
-  }
-
-  private void applyConnectionOptions(Connection conn) throws SQLException {
-    if (options != null) {
-      if (options.isReadOnly()) {
-        conn.setReadOnly(true);
-      }
-      if (options.getCatalog() != null) {
-        conn.setCatalog(options.getCatalog());
-      }
-      if (options.getSchema() != null) {
-        conn.setSchema(options.getSchema());
       }
     }
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCAutoCommit.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCAutoCommit.java
@@ -45,8 +45,4 @@ public class JDBCAutoCommit extends AbstractJDBCAction<Void> {
     return null;
   }
 
-  @Override
-  protected String name() {
-    return "autoCommit";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCAutoCommit.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCAutoCommit.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
 import java.sql.Connection;
@@ -28,8 +27,8 @@ import java.sql.SQLException;
 public class JDBCAutoCommit extends AbstractJDBCAction<Void> {
   private boolean autoCommit;
 
-  public JDBCAutoCommit(SQLOptions options, ContextInternal ctx, boolean autoCommit) {
-    super(options, ctx);
+  public JDBCAutoCommit(SQLOptions options, boolean autoCommit) {
+    super(options);
     this.autoCommit = autoCommit;
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCAutoCommit.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCAutoCommit.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -29,8 +28,8 @@ import java.sql.SQLException;
 public class JDBCAutoCommit extends AbstractJDBCAction<Void> {
   private boolean autoCommit;
 
-  public JDBCAutoCommit(Vertx vertx, SQLOptions options, ContextInternal ctx, boolean autoCommit) {
-    super(vertx, options, ctx);
+  public JDBCAutoCommit(SQLOptions options, ContextInternal ctx, boolean autoCommit) {
+    super(options, ctx);
     this.autoCommit = autoCommit;
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
@@ -122,8 +122,4 @@ public class JDBCBatch extends AbstractJDBCAction<List<Integer>> {
     return list;
   }
 
-  @Override
-  protected String name() {
-    return "batch";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
@@ -42,20 +41,20 @@ public class JDBCBatch extends AbstractJDBCAction<List<Integer>> {
   private final List<JsonArray> in;
   private final List<JsonArray> out;
 
-  public JDBCBatch(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, List<String> sql) {
-    this(vertx, helper, options, ctx, Type.STATEMENT, sql, null, null);
+  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, List<String> sql) {
+    this(helper, options, ctx, Type.STATEMENT, sql, null, null);
   }
 
-  public JDBCBatch(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, List<JsonArray> in) {
-    this(vertx, helper, options, ctx, Type.PREPARED, Collections.singletonList(sql), in, null);
+  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, List<JsonArray> in) {
+    this(helper, options, ctx, Type.PREPARED, Collections.singletonList(sql), in, null);
   }
 
-  public JDBCBatch(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, List<JsonArray> in, List<JsonArray> out) {
-    this(vertx, helper, options, ctx, Type.CALLABLE, Collections.singletonList(sql), in, out);
+  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, List<JsonArray> in, List<JsonArray> out) {
+    this(helper, options, ctx, Type.CALLABLE, Collections.singletonList(sql), in, out);
   }
 
-  private JDBCBatch(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, Type type, List<String> sql, List<JsonArray> in, List<JsonArray> out) {
-    super(vertx, helper, options, ctx);
+  private JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, Type type, List<String> sql, List<JsonArray> in, List<JsonArray> out) {
+    super(helper, options, ctx);
     this.type = type;
     this.sql = sql;
     this.in = in;

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -41,20 +40,20 @@ public class JDBCBatch extends AbstractJDBCAction<List<Integer>> {
   private final List<JsonArray> in;
   private final List<JsonArray> out;
 
-  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, List<String> sql) {
-    this(helper, options, ctx, Type.STATEMENT, sql, null, null);
+  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, List<String> sql) {
+    this(helper, options, Type.STATEMENT, sql, null, null);
   }
 
-  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, List<JsonArray> in) {
-    this(helper, options, ctx, Type.PREPARED, Collections.singletonList(sql), in, null);
+  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, String sql, List<JsonArray> in) {
+    this(helper, options, Type.PREPARED, Collections.singletonList(sql), in, null);
   }
 
-  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, List<JsonArray> in, List<JsonArray> out) {
-    this(helper, options, ctx, Type.CALLABLE, Collections.singletonList(sql), in, out);
+  public JDBCBatch(JDBCStatementHelper helper, SQLOptions options, String sql, List<JsonArray> in, List<JsonArray> out) {
+    this(helper, options, Type.CALLABLE, Collections.singletonList(sql), in, out);
   }
 
-  private JDBCBatch(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, Type type, List<String> sql, List<JsonArray> in, List<JsonArray> out) {
-    super(helper, options, ctx);
+  private JDBCBatch(JDBCStatementHelper helper, SQLOptions options, Type type, List<String> sql, List<JsonArray> in, List<JsonArray> out) {
+    super(helper, options);
     this.type = type;
     this.sql = sql;
     this.in = in;

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCallable.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCallable.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -35,8 +34,8 @@ public class JDBCCallable extends AbstractJDBCAction<io.vertx.ext.sql.ResultSet>
   private final JsonArray in;
   private final JsonArray out;
 
-  public JDBCCallable(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in, JsonArray out) {
-    super(helper, options, ctx);
+  public JDBCCallable(JDBCStatementHelper helper, SQLOptions options, String sql, JsonArray in, JsonArray out) {
+    super(helper, options);
     this.sql = sql;
     this.in = in;
     this.out = out;

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCallable.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCallable.java
@@ -110,8 +110,4 @@ public class JDBCCallable extends AbstractJDBCAction<io.vertx.ext.sql.ResultSet>
     return result;
   }
 
-  @Override
-  protected String name() {
-    return "callable";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCallable.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCallable.java
@@ -16,13 +16,14 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 
-import java.sql.*;
+import java.sql.CallableStatement;
+import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Collections;
 
 /**
@@ -34,8 +35,8 @@ public class JDBCCallable extends AbstractJDBCAction<io.vertx.ext.sql.ResultSet>
   private final JsonArray in;
   private final JsonArray out;
 
-  public JDBCCallable(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in, JsonArray out) {
-    super(vertx, helper, options, ctx);
+  public JDBCCallable(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in, JsonArray out) {
+    super(helper, options, ctx);
     this.sql = sql;
     this.in = in;
     this.out = out;

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCClose.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCClose.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -31,8 +30,8 @@ public class JDBCClose extends AbstractJDBCAction<Void> {
   private final PoolMetrics metrics; // the pool metrics
   private final Object metric;       // the resource managed by the pool metrics
 
-  public JDBCClose(SQLOptions options, ContextInternal ctx, PoolMetrics metrics, Object metric) {
-    super(options, ctx);
+  public JDBCClose(SQLOptions options, PoolMetrics metrics, Object metric) {
+    super(options);
     this.metrics = metrics;
     this.metric = metric;
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCClose.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCClose.java
@@ -48,8 +48,4 @@ public class JDBCClose extends AbstractJDBCAction<Void> {
     return null;
   }
 
-  @Override
-  protected String name() {
-    return "close";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCClose.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCClose.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.ext.sql.SQLOptions;
@@ -32,8 +31,8 @@ public class JDBCClose extends AbstractJDBCAction<Void> {
   private final PoolMetrics metrics; // the pool metrics
   private final Object metric;       // the resource managed by the pool metrics
 
-  public JDBCClose(Vertx vertx, SQLOptions options, ContextInternal ctx, PoolMetrics metrics, Object metric) {
-    super(vertx, options, ctx);
+  public JDBCClose(SQLOptions options, ContextInternal ctx, PoolMetrics metrics, Object metric) {
+    super(options, ctx);
     this.metrics = metrics;
     this.metric = metric;
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCommit.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCommit.java
@@ -37,8 +37,4 @@ public class JDBCCommit extends AbstractJDBCAction<Void> {
     return null;
   }
 
-  @Override
-  protected String name() {
-    return "commit";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCommit.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCommit.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -28,8 +27,8 @@ import java.sql.SQLException;
  */
 public class JDBCCommit extends AbstractJDBCAction<Void> {
 
-  public JDBCCommit(Vertx vertx, SQLOptions options, ContextInternal ctx) {
-    super(vertx, options, ctx);
+  public JDBCCommit(SQLOptions options, ContextInternal ctx) {
+    super(options, ctx);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCommit.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCCommit.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
 import java.sql.Connection;
@@ -27,8 +26,8 @@ import java.sql.SQLException;
  */
 public class JDBCCommit extends AbstractJDBCAction<Void> {
 
-  public JDBCCommit(SQLOptions options, ContextInternal ctx) {
-    super(options, ctx);
+  public JDBCCommit(SQLOptions options) {
+    super(options);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCExecute.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCExecute.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
 import java.sql.Connection;
@@ -31,8 +30,8 @@ public class JDBCExecute extends AbstractJDBCAction<Void> {
 
   private final String sql;
 
-  public JDBCExecute(SQLOptions options, ContextInternal ctx, String sql) {
-    super(options, ctx);
+  public JDBCExecute(SQLOptions options, String sql) {
+    super(options);
     this.sql = sql;
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCExecute.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCExecute.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -32,8 +31,8 @@ public class JDBCExecute extends AbstractJDBCAction<Void> {
 
   private final String sql;
 
-  public JDBCExecute(Vertx vertx, SQLOptions options, ContextInternal ctx, String sql) {
-    super(vertx, options, ctx);
+  public JDBCExecute(SQLOptions options, ContextInternal ctx, String sql) {
+    super(options, ctx);
     this.sql = sql;
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCExecute.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCExecute.java
@@ -56,8 +56,4 @@ public class JDBCExecute extends AbstractJDBCAction<Void> {
     }
   }
 
-  @Override
-  protected String name() {
-    return "execute";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCQuery.java
@@ -16,13 +16,14 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
@@ -32,8 +33,8 @@ public class JDBCQuery extends AbstractJDBCAction<io.vertx.ext.sql.ResultSet> {
   private final String sql;
   private final JsonArray in;
 
-  public JDBCQuery(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
-    super(vertx, helper, options, ctx);
+  public JDBCQuery(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
+    super(helper, options, ctx);
     this.sql = sql;
     this.in = in;
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCQuery.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -33,8 +32,8 @@ public class JDBCQuery extends AbstractJDBCAction<io.vertx.ext.sql.ResultSet> {
   private final String sql;
   private final JsonArray in;
 
-  public JDBCQuery(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
-    super(helper, options, ctx);
+  public JDBCQuery(JDBCStatementHelper helper, SQLOptions options, String sql, JsonArray in) {
+    super(helper, options);
     this.sql = sql;
     this.in = in;
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCQuery.java
@@ -72,8 +72,4 @@ public class JDBCQuery extends AbstractJDBCAction<io.vertx.ext.sql.ResultSet> {
     }
   }
 
-  @Override
-  protected String name() {
-    return "query";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCRollback.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCRollback.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
@@ -28,8 +27,8 @@ import java.sql.SQLException;
  */
 public class JDBCRollback extends AbstractJDBCAction<Void> {
 
-  public JDBCRollback(Vertx vertx, SQLOptions options, ContextInternal ctx) {
-    super(vertx, options, ctx);
+  public JDBCRollback(SQLOptions options, ContextInternal ctx) {
+    super(options, ctx);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCRollback.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCRollback.java
@@ -37,8 +37,4 @@ public class JDBCRollback extends AbstractJDBCAction<Void> {
     return null;
   }
 
-  @Override
-  protected String name() {
-    return "rollback";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCRollback.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCRollback.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.sql.SQLOptions;
 
 import java.sql.Connection;
@@ -27,8 +26,8 @@ import java.sql.SQLException;
  */
 public class JDBCRollback extends AbstractJDBCAction<Void> {
 
-  public JDBCRollback(SQLOptions options, ContextInternal ctx) {
-    super(options, ctx);
+  public JDBCRollback(SQLOptions options) {
+    super(options);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
@@ -35,8 +34,8 @@ public class JDBCUpdate extends AbstractJDBCAction<UpdateResult> {
 
   private boolean generateKeys;
 
-  public JDBCUpdate(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
-    super(vertx, helper, options, ctx);
+  public JDBCUpdate(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
+    super(helper, options, ctx);
     this.sql = sql;
     this.in = in;
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
@@ -129,8 +129,4 @@ public class JDBCUpdate extends AbstractJDBCAction<UpdateResult> {
     }
   }
 
-  @Override
-  protected String name() {
-    return "update";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCUpdate.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 import io.vertx.ext.sql.UpdateResult;
@@ -34,8 +33,8 @@ public class JDBCUpdate extends AbstractJDBCAction<UpdateResult> {
 
   private boolean generateKeys;
 
-  public JDBCUpdate(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
-    super(helper, options, ctx);
+  public JDBCUpdate(JDBCStatementHelper helper, SQLOptions options, String sql, JsonArray in) {
+    super(helper, options);
     this.sql = sql;
     this.in = in;
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.jdbc.impl.actions;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.TaskQueue;
 import io.vertx.core.json.JsonArray;
@@ -39,8 +38,8 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
   private final JsonArray in;
   private final TaskQueue statementsQueue;
 
-  public StreamQuery(Vertx vertx, JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, TaskQueue statementsQueue, String sql, JsonArray in) {
-    super(vertx, helper, options, ctx);
+  public StreamQuery(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, TaskQueue statementsQueue, String sql, JsonArray in) {
+    super(helper, options, ctx);
     this.sql = sql;
     this.in = in;
     this.statementsQueue = statementsQueue;

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
@@ -83,8 +83,4 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
     }
   }
 
-  @Override
-  protected String name() {
-    return "stream";
-  }
 }

--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
@@ -17,7 +17,6 @@
 package io.vertx.ext.jdbc.impl.actions;
 
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.TaskQueue;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 import io.vertx.ext.sql.SQLRowStream;
@@ -34,15 +33,15 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
 
   private static final int DEFAULT_ROW_STREAM_FETCH_SIZE = 128;
 
+  private final ContextInternal ctx;
   private final String sql;
   private final JsonArray in;
-  private final TaskQueue statementsQueue;
 
-  public StreamQuery(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, TaskQueue statementsQueue, String sql, JsonArray in) {
-    super(helper, options, ctx);
+  public StreamQuery(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
+    super(helper, options);
+    this.ctx = ctx;
     this.sql = sql;
     this.in = in;
-    this.statementsQueue = statementsQueue;
   }
 
   @Override
@@ -68,7 +67,7 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
           fetchSize = DEFAULT_ROW_STREAM_FETCH_SIZE;
         }
 
-        return new JDBCSQLRowStream(ctx, this.statementsQueue, st, rs, fetchSize);
+        return new JDBCSQLRowStream(ctx, st, rs, fetchSize);
       } catch (SQLException e) {
         if (rs != null) {
           rs.close();


### PR DESCRIPTION
## Removed runOnContext hops
This makes the code easier to reason about (in particular threading)
    
## Removed statement queues
These are no longer needed as we can now use the serialization provided by executeBlocking on the context bound to the JDBCConnectionImpl instance.
    
## Direct operation execution implementation change
Now it gets a connection then schedules execution on the worker pool.
Previously the operation was executed on the thread that acquires connections (thus serializing all operations on this JDBC client instance).
Also, this avoids to duplicate metrics and connection management (and tracing in the future).
