### PR TITLE
Address issue #210 - Fix for handling of Buffer parameters in prepared statements

### DIFF
--- a/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCPreparedQuery.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCPreparedQuery.java
@@ -150,8 +150,10 @@ public class JDBCPreparedQuery<C, R> extends JDBCQueryAction<C, R> {
       return Timestamp.from(timestamp);
     } else if (value instanceof Buffer) {
       // -> java.sql.Blob
-      Buffer blob = (Buffer) value;
-      return conn.createBlob().setBytes(1, blob.getBytes());
+      Buffer buffer = (Buffer) value;
+      Blob blob = conn.createBlob();
+      blob.setBytes(1, buffer.getBytes());
+      return blob;
     }
 
     return value;

--- a/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCPreparedQuery.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCPreparedQuery.java
@@ -151,7 +151,7 @@ public class JDBCPreparedQuery<C, R> extends JDBCQueryAction<C, R> {
     } else if (value instanceof Buffer) {
       // -> java.sql.Blob
       Buffer blob = (Buffer) value;
-      return conn.createBlob().setBytes(0, blob.getBytes());
+      return conn.createBlob().setBytes(1, blob.getBytes());
     }
 
     return value;

--- a/src/test/java/io/vertx/jdbcclient/JDBCPoolTest.java
+++ b/src/test/java/io/vertx/jdbcclient/JDBCPoolTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.jdbcclient;
 
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.unit.Async;
@@ -350,5 +351,41 @@ public class JDBCPoolTest extends ClientTestBase {
         }));
       }));
     }));
+  }
+  
+  @Test
+  public void testPreparedStatementWithBufferParam(TestContext should) {
+    final Async test = should.async();
+    
+    Buffer buffer = Buffer.buffer("Hello world!");
+    
+    client
+      .query("drop table if exists t")
+      .execute()
+      .onFailure(should::fail)
+      .compose(res1 -> client
+        .query("create table t (b BLOB)")
+        .execute()
+        .onFailure(should::fail)
+        .compose(res2 -> client
+          .preparedQuery("insert into t (b) values (?)")
+          .execute(Tuple.of(buffer))
+          .onFailure(should::fail)
+          .compose(res3 -> client
+            .query("select b from t")
+            .execute()
+            .onFailure(should::fail)
+            .onSuccess(rows -> {
+              should.assertEquals(1, rows.size());
+              rows.forEach(row -> {
+                Buffer actual = row.getBuffer(0);
+                should.assertNotNull(actual);
+                should.assertEquals(buffer, actual);
+              });
+              test.complete();
+            })
+          )
+        )
+      );
   }
 }


### PR DESCRIPTION
This change fixes issue #210 since the handling of Buffer parameters in prepared statements is currently broken.
1. When writing t a Blob the first position is 1.
2. Blob.setBytes() is not a fluent API and returns the number of written bytes.
Additionally the changes adds a regression test.