### PR TITLE
add statements queue to connection && row stream

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/StreamQuery.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.jdbc.impl.actions;
 
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.TaskQueue;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLOptions;
 import io.vertx.ext.sql.SQLRowStream;
@@ -36,12 +37,14 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
   private final ContextInternal ctx;
   private final String sql;
   private final JsonArray in;
+  private final TaskQueue statementsQueue;
 
-  public StreamQuery(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, String sql, JsonArray in) {
+  public StreamQuery(JDBCStatementHelper helper, SQLOptions options, ContextInternal ctx, TaskQueue statementsQueue, String sql, JsonArray in) {
     super(helper, options);
     this.ctx = ctx;
     this.sql = sql;
     this.in = in;
+    this.statementsQueue = statementsQueue;
   }
 
   @Override
@@ -67,7 +70,7 @@ public class StreamQuery extends AbstractJDBCAction<SQLRowStream> {
           fetchSize = DEFAULT_ROW_STREAM_FETCH_SIZE;
         }
 
-        return new JDBCSQLRowStream(ctx, st, rs, fetchSize);
+        return new JDBCSQLRowStream(ctx, this.statementsQueue, st, rs, fetchSize);
       } catch (SQLException e) {
         if (rs != null) {
           rs.close();

--- a/src/test/java/io/vertx/it/MSSQLJDBCParallelTest.java
+++ b/src/test/java/io/vertx/it/MSSQLJDBCParallelTest.java
@@ -1,0 +1,38 @@
+package io.vertx.it;
+
+import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLJDBCParallelTest extends MSSQLTestBase {
+
+  public MSSQLJDBCParallelTest() {
+    poolSize = 10;
+    isJdbcPool = false;
+  }
+
+  @Test(timeout = 15000)
+  public void parallelQueriesPoolTest(TestContext should) {
+    int n = 100;
+    final Async test = should.async(n);
+    for (int i = 1; i <= n; i++) {
+      sqlClient
+        .getConnection(res -> {
+          if (res.succeeded()) {
+            SQLConnection conn = res.result();
+            conn.query("WAITFOR DELAY '00:00:01'", query -> {
+              test.countDown();
+              conn.close();
+            });
+          } else {
+            should.fail(res.cause());
+          }
+        });
+    }
+  }
+
+}

--- a/src/test/java/io/vertx/it/MSSQLParallelTest.java
+++ b/src/test/java/io/vertx/it/MSSQLParallelTest.java
@@ -1,0 +1,41 @@
+package io.vertx.it;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLParallelTest extends MSSQLTestBase {
+
+  public MSSQLParallelTest() {
+    poolSize = 10;
+    isJdbcPool = true;
+  }
+
+  @Test(timeout = 15000)
+  public void parallelQueriesPoolTest(TestContext should) {
+    int n = 100;
+    final Async test = should.async(n);
+    for (int i = 1; i <= n; i++) {
+      client
+        .getConnection()
+        .onSuccess(conn -> {
+          conn.query("WAITFOR DELAY '00:00:01'")
+            .execute()
+            .onSuccess(rows -> {
+              conn.close();
+              test.countDown();
+            })
+            .onFailure(t -> {
+              conn.close();
+              should.fail(t);
+            });
+        })
+        .onFailure(t -> should.fail(t))
+      ;
+    }
+  }
+
+}

--- a/src/test/java/io/vertx/it/MSSQLTest.java
+++ b/src/test/java/io/vertx/it/MSSQLTest.java
@@ -2,69 +2,16 @@ package io.vertx.it;
 
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.jdbcclient.JDBCConnectOptions;
-import io.vertx.jdbcclient.JDBCPool;
-import io.vertx.sqlclient.Cursor;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 @RunWith(VertxUnitRunner.class)
-public class MSSQLTest {
+public class MSSQLTest extends MSSQLTestBase {
 
-  @Rule
-  public final RunTestOnContext rule = new RunTestOnContext();
-
-  private MSSQLServer server;
-  protected JDBCPool client;
-
-  @Before
-  public void before(TestContext should) {
-    final Async test = should.async();
-    rule.vertx().executeBlocking(p -> {
-      try {
-        server = new MSSQLServer();
-        server.withInitScript("init-mssql.sql");
-        server.start();
-        p.complete();
-      } catch (RuntimeException e) {
-        p.fail(e);
-      }
-    }, true, init -> {
-      if (init.succeeded()) {
-        JDBCConnectOptions options = new JDBCConnectOptions()
-          .setJdbcUrl(server.getJdbcUrl())
-          .setUser(server.getUsername())
-          .setPassword(server.getPassword());
-
-        client = JDBCPool.pool(rule.vertx(), options, new PoolOptions().setMaxSize(1));
-        test.complete();
-      } else {
-        should.fail(init.cause());
-      }
-    });
-  }
-
-  @After
-  public void after() {
-    server.close();
-  }
-
-  private static class MSSQLServer extends MSSQLServerContainer {
-    @Override
-    protected void configure() {
-      this.addExposedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT);
-      this.addEnv("ACCEPT_EULA", "Y");
-      this.addEnv("SA_PASSWORD", this.getPassword());
-    }
+  public MSSQLTest() {
+    poolSize = 1;
+    isJdbcPool = true;
   }
 
   @Test
@@ -79,4 +26,5 @@ public class MSSQLTest {
         test.complete();
       }));
   }
+
 }

--- a/src/test/java/io/vertx/it/MSSQLTestBase.java
+++ b/src/test/java/io/vertx/it/MSSQLTestBase.java
@@ -1,0 +1,84 @@
+package io.vertx.it;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.jdbc.JDBCClient;
+import io.vertx.ext.sql.SQLClient;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.jdbcclient.JDBCConnectOptions;
+import io.vertx.jdbcclient.JDBCPool;
+import io.vertx.sqlclient.PoolOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+public abstract class MSSQLTestBase {
+
+  @Rule
+  public final RunTestOnContext rule = new RunTestOnContext();
+
+  private MSSQLServer server;
+  protected JDBCPool client;
+  protected SQLClient sqlClient;
+  protected int poolSize = 1;
+  protected boolean isJdbcPool = true;
+
+  @Before
+  public void before(TestContext should) {
+    final Async test = should.async();
+    rule.vertx().executeBlocking(p -> {
+      try {
+        server = new MSSQLServer();
+        server.withInitScript("init-mssql.sql");
+        server.start();
+        p.complete();
+      } catch (RuntimeException e) {
+        p.fail(e);
+      }
+    }, true, init -> {
+      if (init.succeeded()) {
+        if (isJdbcPool) {
+          JDBCConnectOptions options = new JDBCConnectOptions()
+            .setJdbcUrl(server.getJdbcUrl())
+            .setUser(server.getUsername())
+            .setPassword(server.getPassword());
+
+          client = JDBCPool.pool(rule.vertx(), options, new PoolOptions().setMaxSize(poolSize));
+        } else {
+          sqlClient = JDBCClient.create(rule.vertx(), new JsonObject()
+            .put("url", server.getJdbcUrl())
+            .put("user", server.getUsername())
+            .put("password", server.getPassword())
+            .put("driver_class", "com.microsoft.sqlserver.jdbc.SQLServerDriver")
+            .put("max_pool_size", poolSize));
+        }
+        test.complete();
+      } else {
+        should.fail(init.cause());
+      }
+    });
+  }
+
+  @After
+  public void after() {
+    if (sqlClient != null) {
+      sqlClient.close();
+    }
+    if (client != null) {
+      client.close();
+    }
+    server.close();
+  }
+
+  private static class MSSQLServer extends MSSQLServerContainer {
+    @Override
+    protected void configure() {
+      this.addExposedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT);
+      this.addEnv("ACCEPT_EULA", "Y");
+      this.addEnv("SA_PASSWORD", this.getPassword());
+    }
+  }
+
+}


### PR DESCRIPTION
Signed-off-by: Olga Ivanova <olga.a.ivanova@inbox.ru>

Motivation:

Fix my issue https://github.com/vert-x3/vertx-jdbc-client/issues/217

The problem was in using same queue for different connections (in ContextImpl.executeBlocking).