### PR TITLE
Address issue #226 - Fix for missing close of connection when query fails

### DIFF
--- a/src/main/java/io/vertx/jdbcclient/impl/JDBCPoolImpl.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/JDBCPoolImpl.java
@@ -98,7 +98,7 @@ public class JDBCPoolImpl extends SqlClientBase<JDBCPoolImpl> implements JDBCPoo
   @Override
   public <R> Future<R> schedule(ContextInternal contextInternal, CommandBase<R> commandBase) {
     ContextInternal ctx = vertx.getOrCreateContext();
-    return getConnectionInternal(ctx).flatMap(conn -> ((SqlConnectionImpl<?>) conn).schedule(ctx, commandBase).flatMap(r -> conn.close().map(r)));
+    return getConnectionInternal(ctx).flatMap(conn -> ((SqlConnectionImpl<?>) conn).schedule(ctx, commandBase).eventually(r -> conn.close()));
   }
 
   @Override


### PR DESCRIPTION
This change fixes #226 since the closing of connections for failing queries created by JDBCPool.query(...) or JDBCPool.preparedQuery(...) is currently broken.
Additionally adds according regression tests to JDBCPoolTest.
