### PR TITLE
Adding support for datasources

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
@@ -105,10 +105,10 @@ public class JDBCClientImpl implements JDBCClient, Closeable {
 
     this.vertx = (VertxInternal) vertx;
     this.datasourceName = UUID.randomUUID().toString();
-    this.config = new JsonObject();
+    this.config = dataSourceProvider.getInitialConfig();
     holders = vertx.sharedData().getLocalMap(DS_LOCAL_MAP_NAME);
     holders.compute(datasourceName, (k, h) -> h == null ? new DataSourceHolder(dataSourceProvider) : h.increment());
-    this.helper = new JDBCStatementHelper(dataSourceProvider.getInitialConfig());
+    this.helper = new JDBCStatementHelper(this.config);
     setupCloseHook();
   }
 

--- a/src/main/java/io/vertx/jdbcclient/JDBCPool.java
+++ b/src/main/java/io/vertx/jdbcclient/JDBCPool.java
@@ -29,6 +29,7 @@ import io.vertx.jdbcclient.impl.JDBCPoolImpl;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
+import javax.sql.DataSource;
 import java.util.UUID;
 
 /**
@@ -108,5 +109,27 @@ public interface JDBCPool extends Pool {
       context.tracer() == null ?
         null :
         new QueryTracer(context.tracer(), TracingPolicy.PROPAGATE, jdbcUrl, user, config.getString("database")));
+  }
+
+  /**
+   * Create a JDBC pool using a pre-initialized data source. The config expects that at least the following properties
+   * are set:
+   *
+   * <ul>
+   *   <li>{@code url} - the connection string</li>
+   *   <li>{@code user} - the connection user name</li>
+   *   <li>{@code database} - the database name</li>
+   *   <li>{@code maxPoolSize} - the max allowed number of connections in the pool</li>
+   * </ul>
+   *
+   * @param vertx  the Vert.x instance
+   * @param dataSource a pre-initialized data source
+   * @param config the pool configuration
+   * @return the client
+   * @since 4.2.0
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  static JDBCPool pool(Vertx vertx, DataSource dataSource, JsonObject config) {
+    return pool(vertx, DataSourceProvider.create(dataSource, config));
   }
 }

--- a/src/test/java/io/vertx/jdbcclient/JDBCPoolInitTest.java
+++ b/src/test/java/io/vertx/jdbcclient/JDBCPoolInitTest.java
@@ -1,5 +1,6 @@
 package io.vertx.jdbcclient;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.h2.Driver;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +12,8 @@ import io.vertx.ext.jdbc.spi.impl.AgroalCPDataSourceProvider;
 import io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider;
 import io.vertx.ext.jdbc.spi.impl.HikariCPDataSourceProvider;
 import io.vertx.ext.unit.TestContext;
+
+import javax.sql.DataSource;
 
 public class JDBCPoolInitTest extends ClientTestBase {
 
@@ -78,5 +81,19 @@ public class JDBCPoolInitTest extends ClientTestBase {
     client.query("SELECT * FROM INFORMATION_SCHEMA.TABLES")
           .execute()
           .onComplete(should.asyncAssertSuccess(rows -> should.assertTrue(rows.size() > 0)));
+  }
+
+  @Test
+  public void test_init_pool_by_existing_datasource(TestContext should) {
+    final JsonObject config = new JsonObject()
+      .put("url", "jdbc:h2:mem:testDB?shutdown=true")
+      .put("user", "")
+      .put("database", "testDB")
+      .put("maxPoolSize", 10);
+
+    HikariDataSource ds = new HikariDataSource();
+    ds.setJdbcUrl("jdbc:h2:mem:testDB?shutdown=true");
+    client = JDBCPool.pool(vertx, ds, config);
+    simpleAssertSuccess(should);
   }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

There are cases when data sources can be provided to the system, this PR just enables their use in the public API.