### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/test/java/io/vertx/ext/jdbc/PoolTest.java
+++ b/src/test/java/io/vertx/ext/jdbc/PoolTest.java
@@ -76,6 +76,7 @@ public class PoolTest extends VertxTestBase {
     try {
       Thread.sleep(howLong);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return -1;
     }
     return howLong;


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.