### PR TITLE
fix batch complexity, p.2

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/actions/JDBCBatch.java
@@ -84,8 +84,8 @@ public class JDBCBatch extends AbstractJDBCAction<List<Integer>> {
           applyStatementOptions(stmt);
 
           if (!this.in.isEmpty()) {
-            JDBCColumnDescriptorProvider provider = JDBCColumnDescriptorProvider.fromParameterMetaData(stmt.getParameterMetaData());
             for (JsonArray in : this.in) {
+              JDBCColumnDescriptorProvider provider = JDBCColumnDescriptorProvider.fromParameterMetaData(stmt.getParameterMetaData());
               fillStatement(stmt, in, provider);
               stmt.addBatch();
             }
@@ -104,8 +104,8 @@ public class JDBCBatch extends AbstractJDBCAction<List<Integer>> {
           final int max_in_out = Math.max(max_in, max_out);
 
           if (max_in_out > 0) {
-            JDBCColumnDescriptorProvider provider = JDBCColumnDescriptorProvider.fromParameterMetaData(stmt.getParameterMetaData());
             for (int i = 0; i < max_in_out; i++) {
+              JDBCColumnDescriptorProvider provider = JDBCColumnDescriptorProvider.fromParameterMetaData(stmt.getParameterMetaData());
               final JsonArray jin = i < max_in ? in.get(i) : null;
               final JsonArray jout = i < max_out ? out.get(i) : null;
               fillStatement(stmt, jin, jout, provider);


### PR DESCRIPTION
Continues #260
Some jdbc drivers (again, postgre at least) can change the metadata of a statement while it is being populated (see [here](https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java#L1384-L1429)). We must request metadata at every step of the loop. Alternatively, we can use something like `CachedParameterMetaData` which will be populated in the very first step.
What do you think @pmlopes ?