### PR TITLE
Add missing @Source annotation to all examples

### DIFF
--- a/src/main/java/examples/JDBCTypeExamples.java
+++ b/src/main/java/examples/JDBCTypeExamples.java
@@ -2,6 +2,7 @@ package examples;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.docgen.Source;
 import io.vertx.ext.jdbc.JDBCClient;
 import io.vertx.ext.jdbc.spi.DataSourceProvider;
 import io.vertx.ext.jdbc.spi.JDBCDecoder;
@@ -17,6 +18,7 @@ import java.sql.Date;
 import java.sql.JDBCType;
 import java.time.LocalDate;
 
+@Source
 public class JDBCTypeExamples {
 
   public static class DerbyEncoder extends JDBCEncoderImpl {


### PR DESCRIPTION
The documentation on the website contains invalid code snippets:
https://vertx.io/docs/vertx-jdbc-client/java/#_data_types

It seems `JDBCTypeExamples.java` misses the `@Sample` annotation from the `vertx-docgen` project. This pull request adds this annotation.

I tested the doc generation with this change and the snippets are correctly included.