### PR TITLE
Switched to Agroal as the default pool provider.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
       <version>0.9.5.5</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
@@ -83,13 +84,11 @@
       <groupId>io.agroal</groupId>
       <artifactId>agroal-api</artifactId>
       <version>1.16</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.agroal</groupId>
       <artifactId>agroal-pool</artifactId>
       <version>1.16</version>
-      <optional>true</optional>
     </dependency>
 
     <!-- Testing -->

--- a/src/main/java/io/vertx/ext/jdbc/JDBCClient.java
+++ b/src/main/java/io/vertx/ext/jdbc/JDBCClient.java
@@ -37,9 +37,9 @@ import java.util.UUID;
 public interface JDBCClient extends SQLClient {
 
   /**
-   * The default data source provider is C3P0
+   * The default data source provider is Agroal
    */
-  String DEFAULT_PROVIDER_CLASS =  "io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider";
+  String DEFAULT_PROVIDER_CLASS =  "io.vertx.ext.jdbc.spi.impl.AgroalCPDataSourceProvider";
 
   /**
    * The name of the default data source


### PR DESCRIPTION
Fixes the behavior described in #277 where the library fails by default since it tries to use Agroal when it's an optional dependency.