### PR TITLE
Make data source name configurable through JDBCPool

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -548,6 +548,8 @@ The following configuration properties generally apply:
 this property and provide your implementation.
 `row_stream_fetch_size`:: The size of `SQLRowStream` internal cache which used to better performance. By default
 it equals to `128`
+`datasourceName`:: Name of the data source. Pool metrics will be reported under this name. By default, random
+UUID is generated.
 
 Assuming the C3P0 implementation is being used (the default), the following extra configuration properties apply:
 

--- a/src/main/java/examples/JDBCSqlClientExamples.java
+++ b/src/main/java/examples/JDBCSqlClientExamples.java
@@ -24,7 +24,14 @@ import java.time.Instant;
 @Source
 public class JDBCSqlClientExamples {
 
-  public void exampleCreateDefault(Vertx vertx, JsonObject config) {
+  public void exampleCreateDefault(Vertx vertx) {
+    final JsonObject config = new JsonObject()
+      .put("jdbcUrl", "jdbc:h2:~/test")
+      .put("datasourceName", "pool-name")
+      .put("username", "sa")
+      .put("password", "")
+      .put("max_pool_size", 16);
+
     JDBCPool pool = JDBCPool.pool(vertx, config);
   }
 
@@ -43,6 +50,7 @@ public class JDBCSqlClientExamples {
       // configure the pool
       new PoolOptions()
         .setMaxSize(16)
+        .setName("pool-name")
     );
 
   }

--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
@@ -100,11 +100,22 @@ public class JDBCClientImpl implements JDBCClient, Closeable {
    * Create client with shared datasource.
    */
   public JDBCClientImpl(Vertx vertx, DataSourceProvider dataSourceProvider) {
+    this(
+      vertx,
+      dataSourceProvider,
+      dataSourceProvider.getInitialConfig().getString("datasourceName", DEFAULT_DS_NAME)
+    );
+  }
+
+  /**
+   * Create client with shared datasource.
+   */
+  public JDBCClientImpl(Vertx vertx, DataSourceProvider dataSourceProvider, final String datasourceName) {
     Objects.requireNonNull(vertx);
     Objects.requireNonNull(dataSourceProvider);
 
     this.vertx = (VertxInternal) vertx;
-    this.datasourceName = UUID.randomUUID().toString();
+    this.datasourceName = datasourceName;
     this.config = dataSourceProvider.getInitialConfig();
     holders = vertx.sharedData().getLocalMap(DS_LOCAL_MAP_NAME);
     holders.compute(datasourceName, (k, h) -> h == null ? new DataSourceHolder(dataSourceProvider) : h.increment());

--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCClientImpl.java
@@ -103,7 +103,7 @@ public class JDBCClientImpl implements JDBCClient, Closeable {
     this(
       vertx,
       dataSourceProvider,
-      dataSourceProvider.getInitialConfig().getString("datasourceName", DEFAULT_DS_NAME)
+      dataSourceProvider.getInitialConfig().getString("datasourceName", UUID.randomUUID().toString())
     );
   }
 

--- a/src/main/java/io/vertx/ext/jdbc/spi/DataSourceProvider.java
+++ b/src/main/java/io/vertx/ext/jdbc/spi/DataSourceProvider.java
@@ -18,6 +18,7 @@ package io.vertx.ext.jdbc.spi;
 
 import java.sql.SQLException;
 import java.util.Objects;
+import java.util.UUID;
 import javax.sql.DataSource;
 
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/io/vertx/jdbcclient/JDBCPool.java
+++ b/src/main/java/io/vertx/jdbcclient/JDBCPool.java
@@ -62,7 +62,7 @@ public interface JDBCPool extends Pool {
 
     return new JDBCPoolImpl(
       vertx,
-      new JDBCClientImpl(vertx, new AgroalCPDataSourceProvider(connectOptions, poolOptions)),
+      new JDBCClientImpl(vertx, new AgroalCPDataSourceProvider(connectOptions, poolOptions), poolOptions.getName()),
       connectOptions,
       context.tracer() == null ?
         null :
@@ -105,6 +105,7 @@ public interface JDBCPool extends Pool {
     String jdbcUrl = config.getString("jdbcUrl", config.getString("url"));
     String user = config.getString("username", config.getString("user"));
     String database = config.getString("database");
+    String datasourceName = config.getString("datasourceName", UUID.randomUUID().toString());
     if (context.tracer() != null) {
       Objects.requireNonNull(jdbcUrl, "data source url config cannot be null");
       Objects.requireNonNull(user, "data source user config cannot be null");
@@ -112,7 +113,7 @@ public interface JDBCPool extends Pool {
     }
     return new JDBCPoolImpl(
       vertx,
-      new JDBCClientImpl(vertx, dataSourceProvider),
+      new JDBCClientImpl(vertx, dataSourceProvider, datasourceName),
       new SQLOptions(config),
       context.tracer() == null ?
         null :

--- a/src/main/java/io/vertx/jdbcclient/JDBCPool.java
+++ b/src/main/java/io/vertx/jdbcclient/JDBCPool.java
@@ -105,7 +105,6 @@ public interface JDBCPool extends Pool {
     String jdbcUrl = config.getString("jdbcUrl", config.getString("url"));
     String user = config.getString("username", config.getString("user"));
     String database = config.getString("database");
-    String datasourceName = config.getString("datasourceName", UUID.randomUUID().toString());
     if (context.tracer() != null) {
       Objects.requireNonNull(jdbcUrl, "data source url config cannot be null");
       Objects.requireNonNull(user, "data source user config cannot be null");
@@ -113,7 +112,7 @@ public interface JDBCPool extends Pool {
     }
     return new JDBCPoolImpl(
       vertx,
-      new JDBCClientImpl(vertx, dataSourceProvider, datasourceName),
+      new JDBCClientImpl(vertx, dataSourceProvider),
       new SQLOptions(config),
       context.tracer() == null ?
         null :

--- a/src/main/java/io/vertx/jdbcclient/JDBCPool.java
+++ b/src/main/java/io/vertx/jdbcclient/JDBCPool.java
@@ -80,9 +80,10 @@ public interface JDBCPool extends Pool {
     final ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
     String jdbcUrl = config.getString("jdbcUrl", config.getString("url"));
     String user = config.getString("username", config.getString("user"));
+    String datasourceName = config.getString("datasourceName", UUID.randomUUID().toString());
     return new JDBCPoolImpl(
       vertx,
-      new JDBCClientImpl(vertx, config, UUID.randomUUID().toString()),
+      new JDBCClientImpl(vertx, config, datasourceName),
       new SQLOptions(config),
       context.tracer() == null ?
         null :

--- a/src/test/java/io/vertx/it/ClickHouseOldAPITest.java
+++ b/src/test/java/io/vertx/it/ClickHouseOldAPITest.java
@@ -36,6 +36,7 @@ public class ClickHouseOldAPITest {
 
   @After
   public void after(TestContext ctx) {
+    System.out.println(container.getLogs());
     container.stop();
     vertx.close(ctx.asyncAssertSuccess());
     client.close(ctx.asyncAssertSuccess());

--- a/src/test/java/io/vertx/jdbcclient/JDBCPoolInitTest.java
+++ b/src/test/java/io/vertx/jdbcclient/JDBCPoolInitTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(VertxUnitRunner.class)
 public class JDBCPoolInitTest extends ClientTestBase {
 
-  private volatile String poolMetricsPoolName;
+  private String poolMetricsPoolName;
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
Motivation:

With the old JDBC Client API it was possible to configure the data source name, but this option is not available when using JDBCPool that wraps the old JDBCClient into the new SQL Client API.

Instead, a random UUID is always used as the data source name. This causes a lot of problems with metrics such as:

a) It's impossible to know which data source the random UUID maps to. This can be a problem with projects using multiple data sources to different databases.

b) The data source names change on each deployment, which makes it impossible to follow trends over time.

c) Can add to the operating costs when there are a huge amount of servers when using e.g. CloudWatch which is billed per metric.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
