### PR TITLE
Make tests runnable on M1 Macs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,11 +140,10 @@
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mssqlserver</artifactId>
-      <version>1.15.2</version>
+      <version>1.17.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -156,7 +155,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>clickhouse</artifactId>
-      <version>1.15.2</version>
+      <version>1.17.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -174,13 +173,13 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>oracle-xe</artifactId>
-      <version>1.15.2</version>
+      <version>1.17.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>1.15.2</version>
+      <version>1.17.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/io/vertx/it/ClickHouseOldAPITest.java
+++ b/src/test/java/io/vertx/it/ClickHouseOldAPITest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @RunWith(VertxUnitRunner.class)
 public class ClickHouseOldAPITest {
@@ -25,7 +26,7 @@ public class ClickHouseOldAPITest {
   @Before
   public void setUp() {
     vertx = Vertx.vertx();
-    container = new ClickHouseContainer("yandex/clickhouse-server:20.8");
+    container = new ClickHouseContainer("clickhouse/clickhouse-server:22.8-alpine");
     container.withInitScript("init-clickhouse.sql");
     container.start();
     JsonObject config = new JsonObject()

--- a/src/test/java/io/vertx/it/ClickHouseTest.java
+++ b/src/test/java/io/vertx/it/ClickHouseTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @RunWith(VertxUnitRunner.class)
 public class ClickHouseTest {
@@ -24,7 +25,7 @@ public class ClickHouseTest {
   @Before
   public void setUp() {
     vertx = Vertx.vertx();
-    container = new ClickHouseContainer("yandex/clickhouse-server:20.8");
+    container = new ClickHouseContainer("clickhouse/clickhouse-server:22.8-alpine");
     container.withInitScript("init-clickhouse.sql");
     container.start();
     JsonObject config = new JsonObject()

--- a/src/test/java/io/vertx/jdbcclient/JDBCPoolTest.java
+++ b/src/test/java/io/vertx/jdbcclient/JDBCPoolTest.java
@@ -433,19 +433,21 @@ public class JDBCPoolTest extends ClientTestBase {
       .withConnection(conn -> conn
         .query(sql)
         .execute()
-        .onFailure(err -> {
-          should.assertTrue(err instanceof SQLSyntaxErrorException, "Broken SQL should fail with SQLSyntaxErrorException");
-          client
-            .withConnection(conn2 -> conn2
-              .query(sql)
-              .execute()
-              .onFailure(err2 -> {
-                should.assertTrue(err2 instanceof SQLSyntaxErrorException, "Broken SQL should fail with SQLSyntaxErrorException");
-                test.complete();
-              })
-              .onSuccess(rows -> should.fail("Broken SQL should fail")));
-      })
-      .onSuccess(rows -> should.fail("Broken SQL should fail")));
+      )
+      .onSuccess(rows -> should.fail("Broken SQL should fail"))
+      .onFailure(err -> {
+        should.assertTrue(err instanceof SQLSyntaxErrorException, "Broken SQL should fail with SQLSyntaxErrorException");
+        client
+          .withConnection(conn2 -> conn2
+            .query(sql)
+            .execute()
+            .onFailure(err2 -> {
+              should.assertTrue(err2 instanceof SQLSyntaxErrorException, "Broken SQL should fail with SQLSyntaxErrorException");
+              test.complete();
+            })
+            .onSuccess(rows -> should.fail("Broken SQL should fail"))
+          );
+      });
   }
 
   @Test


### PR DESCRIPTION
Motivation:

The test containers version is not compatible with M1 Macs. This upgrades the test containers to a more recent version with proper aarch64 support.

Also, the yandex/clickhouse-server image is not compatible with aarch64. Afaik, the yandex/clickhouse-server is anyway deprecated, so changed the tests to use clickhouse/clickhouse-server that has aarch64 support in newer tags.

After these, it's possible to run most of the test suite (except Oracle and MSSQL cases) on M1 Macs. Tested with 16" M1 Max MBP.

There was one test (`testConnectionReturnedToPoolOnFailingQueryExecutionWhenUsingWithConnection`) that seemed to be flaky. More often than not locally it seemed to deadlock waiting for the second connection. I fixed the test by moving the second `withConnection` to happen _after_ the first connection had been released. But I'm not sure if this is potentially a bug in the implementation that should be investigated more, or if it was only a bug in the test.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
