### PR TITLE
Fix ClickHouseOldAPITest timeout on CI

### DIFF
--- a/src/test/java/io/vertx/it/ClickHouseOldAPITest.java
+++ b/src/test/java/io/vertx/it/ClickHouseOldAPITest.java
@@ -7,8 +7,6 @@ import io.vertx.ext.jdbc.JDBCClient;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.jdbcclient.JDBCPool;
-import io.vertx.sqlclient.Row;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,11 +33,14 @@ public class ClickHouseOldAPITest {
   }
 
   @After
-  public void after(TestContext ctx) {
-    System.out.println(container.getLogs());
-    container.stop();
-    vertx.close(ctx.asyncAssertSuccess());
-    client.close(ctx.asyncAssertSuccess());
+  public void after(TestContext should) {
+    Async cleanup = should.async();
+    client.close(should.asyncAssertSuccess(res1 -> {
+      vertx.close(should.asyncAssertSuccess(res2 -> {
+          container.close();
+          cleanup.complete();
+      }));
+    }));
   }
 
   @Test

--- a/src/test/java/io/vertx/it/ClickHouseTest.java
+++ b/src/test/java/io/vertx/it/ClickHouseTest.java
@@ -34,10 +34,14 @@ public class ClickHouseTest {
   }
 
   @After
-  public void after(TestContext ctx) {
-    container.stop();
-    vertx.close(ctx.asyncAssertSuccess());
-    client.close(ctx.asyncAssertSuccess());
+  public void after(TestContext should) {
+    Async cleanup = should.async();
+    client.close(should.asyncAssertSuccess(res1 -> {
+      vertx.close(should.asyncAssertSuccess(res2 -> {
+        container.close();
+        cleanup.complete();
+      }));
+    }));
   }
 
   @Test


### PR DESCRIPTION
Motivation:

ClickHouseOldAPITest is timing out on CI

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
