### PR TITLE
Fix tracing integration with JDBC SQL client

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/jdbc/impl/JDBCConnectionImpl.java
@@ -22,6 +22,7 @@ import io.vertx.core.impl.TaskQueue;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.ext.jdbc.impl.actions.*;
 import io.vertx.ext.sql.*;
@@ -43,23 +44,29 @@ public class JDBCConnectionImpl implements SQLConnection {
   private final PoolMetrics metrics;
   private final Object metric;
   private final TaskQueue statementsQueue = new TaskQueue();
+  private final SocketAddress server;
 
   private final JDBCStatementHelper helper;
 
   private SQLOptions options;
 
-  public JDBCConnectionImpl(Context context, JDBCStatementHelper helper, Connection conn, PoolMetrics metrics, Object metric) {
+  public JDBCConnectionImpl(Context context, JDBCStatementHelper helper, Connection conn, PoolMetrics metrics, Object metric, SocketAddress server) {
     this.helper = helper;
     this.conn = conn;
     this.metrics = metrics;
     this.metric = metric;
     this.ctx = (ContextInternal) context;
+    this.server = server;
   }
 
   @Override
   public synchronized SQLConnection setOptions(SQLOptions options) {
     this.options = options;
     return this;
+  }
+
+  public SocketAddress server() {
+    return server;
   }
 
   private synchronized SQLOptions getOptions() {

--- a/src/main/java/io/vertx/jdbcclient/JDBCPool.java
+++ b/src/main/java/io/vertx/jdbcclient/JDBCPool.java
@@ -57,8 +57,6 @@ public interface JDBCPool extends Pool {
    * @return the client
    */
   static JDBCPool pool(Vertx vertx, JDBCConnectOptions connectOptions, PoolOptions poolOptions) {
-    final ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
-
     return new JDBCPoolImpl(
       vertx,
       new JDBCClientImpl(vertx, new AgroalCPDataSourceProvider(connectOptions, poolOptions), poolOptions.getName()),

--- a/src/main/java/io/vertx/jdbcclient/impl/ConnectionImpl.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/ConnectionImpl.java
@@ -80,7 +80,7 @@ public class ConnectionImpl implements Connection {
 
   @Override
   public SocketAddress server() {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return conn.server();
   }
 
   @Override

--- a/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
+++ b/src/test/java/io/vertx/ext/jdbc/JDBCClientTestBase.java
@@ -68,13 +68,17 @@ public abstract class JDBCClientTestBase extends VertxTestBase {
   }
 
   public static void resetDb(Class<?> clazz) throws Exception {
+    resetDb(clazz, SQL);
+  }
+
+  public static void resetDb(Class<?> clazz, List<String> statements) throws Exception {
     Connection conn = DriverManager.getConnection(DBConfigs.hsqldb(clazz).getString("url"));
-    for (String sql : SQL) {
-      conn.createStatement().execute(sql);
+    for (String statement : statements) {
+      conn.createStatement().execute(statement);
     }
   }
 
-//  @Rule
+  //  @Rule
 //  public ThreadLeakCheckerRule rule = new ThreadLeakCheckerRule();
 
   protected SQLClient client;

--- a/src/test/java/io/vertx/jdbcclient/JDBCTracingTest.java
+++ b/src/test/java/io/vertx/jdbcclient/JDBCTracingTest.java
@@ -1,0 +1,90 @@
+package io.vertx.jdbcclient;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.jdbc.DBConfigs;
+import io.vertx.ext.jdbc.JDBCClientTestBase;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.tck.TracingTestBase;
+import org.junit.Assume;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+@RunWith(VertxUnitRunner.class)
+public class JDBCTracingTest extends TracingTestBase {
+
+  private static final List<String> SQL;
+
+  static {
+    SQL = Arrays.asList(("DROP TABLE IF EXISTS immutable;\n" +
+      "CREATE TABLE immutable (id integer NOT NULL, message varchar(2048) NOT NULL, PRIMARY KEY (id));\n" +
+      "INSERT INTO immutable (id, message) VALUES (1, 'fortune: No such file or directory');\n" +
+      "INSERT INTO immutable (id, message) VALUES (2, 'A computer scientist is someone who fixes things that aren''t broken.');\n" +
+      "INSERT INTO immutable (id, message) VALUES (3, 'After enough decimal places, nobody gives a damn.');\n" +
+      "INSERT INTO immutable (id, message) VALUES (4, 'A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1');\n" +
+      "INSERT INTO immutable (id, message) VALUES (5, 'A computer program does what you tell it to do, not what you want it to do.');\n" +
+      "INSERT INTO immutable (id, message) VALUES (6, 'Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen');\n" +
+      "INSERT INTO immutable (id, message) VALUES (7, 'Any program that runs right is obsolete.');\n" +
+      "INSERT INTO immutable (id, message) VALUES (8, 'A list is only as strong as its weakest link. — Donald Knuth');\n" +
+      "INSERT INTO immutable (id, message) VALUES (9, 'Feature: A bug with seniority.');\n" +
+      "INSERT INTO immutable (id, message) VALUES (10, 'Computers make very fast, very accurate mistakes.');\n" +
+      "INSERT INTO immutable (id, message) VALUES (11, '<script>alert(\"This should not be displayed in a browser alert box.\");</script>');\n" +
+      "INSERT INTO immutable (id, message) VALUES (12, 'フレームワークのベンチマーク');").split("\n"));
+
+  }
+
+  private JDBCPool pool;
+
+  @Override
+  public void setup() throws Exception {
+    JDBCClientTestBase.resetDb(ClientTestBase.class, SQL);
+    super.setup();
+  }
+
+  @Override
+  public void teardown(TestContext ctx) {
+    JDBCPool p = pool;
+    pool = null;
+    if (p != null) {
+      try {
+        p.close().toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+      } catch (Exception ignore) {
+      }
+    }
+    super.teardown(ctx);
+  }
+
+  @Override
+  protected Pool createPool(Vertx vertx) {
+    if (pool == null) {
+      pool = JDBCPool.pool(vertx, new JDBCConnectOptions()
+        .setJdbcUrl(DBConfigs.hsqldb(ClientTestBase.class).getString("url")), new PoolOptions());
+    }
+    return pool;
+  }
+
+  @Override
+  protected String statement(String... parts) {
+    return String.join("?", parts);
+  }
+
+  @Override
+  public void testTraceBatchQuery(TestContext ctx) {
+    Assume.assumeTrue(false);
+  }
+
+  @Override
+  public void testTracePooledBatchQuery(TestContext ctx) {
+    Assume.assumeTrue(false);
+  }
+}


### PR DESCRIPTION
The tracing integration is broken because it requires to use the server socket address to report tracing information and the JDBC API does not naturally provides it.

We should try to determine the server address with a best effort to allow proper tracing reporting.