### PR TITLE
Fix issue #323: Added option to set 'exceptionOverrideClassName' on H…

### DIFF
--- a/src/main/java/io/vertx/ext/jdbc/spi/impl/HikariCPDataSourceProvider.java
+++ b/src/main/java/io/vertx/ext/jdbc/spi/impl/HikariCPDataSourceProvider.java
@@ -141,6 +141,9 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
         case "leakDetectionThreshold":
           config.setLeakDetectionThreshold(getLong(entry.getValue()));
           break;
+        case "exceptionOverrideClassName":
+          config.setExceptionOverrideClassName((String)entry.getValue());
+          break;
         case "dataSource":
           throw new UnsupportedOperationException(entry.getKey());
         case "threadFactory":


### PR DESCRIPTION
HikariCPDataSourceProvider

Motivation:

I need to be able to set the exceptionOverrideClassName on the HikariConfig object. I need this change both for versions 4.4.x and 4.5.x
