### PR TITLE
SQL Server driver may throw SQLException when getGeneratedKeys is invoked

### DIFF
--- a/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCQueryAction.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCQueryAction.java
@@ -11,21 +11,16 @@
 
 package io.vertx.jdbcclient.impl.actions;
 
-import io.vertx.jdbcclient.spi.JDBCColumnDescriptorProvider;
-import io.vertx.jdbcclient.spi.JDBCDecoder;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.jdbcclient.SqlOptions;
 import io.vertx.jdbcclient.impl.JDBCRow;
+import io.vertx.jdbcclient.spi.JDBCColumnDescriptorProvider;
+import io.vertx.jdbcclient.spi.JDBCDecoder;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
 
-import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.ParameterMetaData;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.function.BiConsumer;
 import java.util.stream.Collector;
 
@@ -33,6 +28,8 @@ import java.util.stream.Collector;
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
 public abstract class JDBCQueryAction<C, R> extends AbstractJDBCAction<JDBCResponse<R>> {
+
+  private static final Logger log = LoggerFactory.getLogger(JDBCQueryAction.class);
 
   private final Collector<Row, C, R> collector;
 
@@ -171,10 +168,14 @@ public abstract class JDBCQueryAction<C, R> extends AbstractJDBCAction<JDBCRespo
   }
 
   private void decodeReturnedKeys(Statement statement, JDBCResponse<R> response) throws SQLException {
-    Row keys = null;
-
-    ResultSet keysRS = statement.getGeneratedKeys();
-
+    ResultSet keysRS;
+    try {
+      keysRS = statement.getGeneratedKeys();
+    } catch (SQLException e) {
+      // MS SQL Server may throw an exception after invoking a stored procedure that didn't actually execute any statement
+      log.trace("Failed to retrieve generated keys, skipping", e);
+      return;
+    }
     if (keysRS != null) {
       if (keysRS.next()) {
         // only try to access metadata if there are rows
@@ -182,6 +183,7 @@ public abstract class JDBCQueryAction<C, R> extends AbstractJDBCAction<JDBCRespo
         if (metaData != null) {
           JDBCColumnDescriptorProvider provider = JDBCColumnDescriptorProvider.fromResultMetaData(metaData);
           int cols = metaData.getColumnCount();
+          Row keys = null;
           if (cols > 0) {
             JDBCRowDesc keysDesc = new JDBCRowDesc(provider, cols);
 

--- a/src/test/java/io/vertx/it/MSSQLTest.java
+++ b/src/test/java/io/vertx/it/MSSQLTest.java
@@ -212,6 +212,28 @@ public class MSSQLTest {
   }
 
   @Test
+  public void testConditionalStoredProcedure() throws Exception {
+    final Pool client = initJDBCPool();
+
+    RowSet<Row> rows = client
+      .preparedQuery("{ call conditional_proc(?)}")
+      .execute(Tuple.of(0))
+      .await(20, TimeUnit.SECONDS);
+
+    // Should complete without throwing any exception
+    assertNotNull(rows);
+
+    rows = client
+      .preparedQuery("{ call conditional_proc(?)}")
+      .execute(Tuple.of(1))
+      .await(20, TimeUnit.SECONDS);
+
+    assertNotNull(rows);
+    assertEquals(1, rows.size());
+    assertEquals("One", rows.iterator().next().getString(0));
+  }
+
+  @Test
   public void testQueryWithJDBCPool() throws Exception {
     final Pool client = initJDBCPool();
     RowSet<Row> rows = client

--- a/src/test/resources/init-mssql.sql
+++ b/src/test/resources/init-mssql.sql
@@ -27,6 +27,19 @@ end;
 
 GO
 
+-- Make sure the client does not fail
+-- When executing a procedure that can (conditionally) return no result set
+CREATE procedure [dbo].[conditional_proc]
+  @number int
+as
+begin
+IF
+(@number = 1)
+SELECT 'One'
+end;
+
+GO
+
 -- TCK usage --
 -- immutable for select query testing --
 DROP TABLE IF EXISTS immutable;

--- a/src/test/resources/init-pgsql.sql
+++ b/src/test/resources/init-pgsql.sql
@@ -49,6 +49,19 @@ BEGIN
   b3:= true;
 END;' LANGUAGE plpgsql;
 
+-- Make sure the client does not fail
+-- When executing a procedure that can (conditionally) return no result set
+CREATE FUNCTION conditional_proc(p_number INTEGER)
+  RETURNS TABLE
+          (
+            result TEXT
+          ) AS '
+BEGIN
+  IF p_number = 1 THEN
+    RETURN QUERY SELECT ''One''::TEXT;
+  END IF;
+END;' LANGUAGE plpgsql;
+
 CREATE TABLE temporal_data_type
 (
   "id"          INTEGER NOT NULL PRIMARY KEY,


### PR DESCRIPTION
See #311

If a stored procedure is invoked, and conditionally returns no result, the SQL Server driver may throw Exception.

In this commit, the SQLException is caught and logged at trace level.

There are tests that verify the behavior is ok with different databases (Pg and MSSQL).