### PR TITLE
SQL Server driver may throw SQLException when getGeneratedKeys is invoked

### DIFF
--- a/src/test/resources/init-mssql.sql
+++ b/src/test/resources/init-mssql.sql
@@ -27,6 +27,19 @@ end;
 
 GO
 
+-- Make sure the client does not fail
+-- When executing a procedure that can (conditionally) return no result set
+CREATE procedure [dbo].[conditional_proc]
+  @number int
+as
+begin
+IF
+(@number = 1)
+SELECT 'One'
+end;
+
+GO
+
 -- TCK usage --
 -- immutable for select query testing --
 DROP TABLE IF EXISTS immutable;

--- a/src/test/resources/init-pgsql.sql
+++ b/src/test/resources/init-pgsql.sql
@@ -49,6 +49,19 @@ BEGIN
   b3:= true;
 END;' LANGUAGE plpgsql;
 
+-- Make sure the client does not fail
+-- When executing a procedure that can (conditionally) return no result set
+CREATE FUNCTION conditional_proc(p_number INTEGER)
+  RETURNS TABLE
+          (
+            result TEXT
+          ) AS '
+BEGIN
+  IF p_number = 1 THEN
+    RETURN QUERY SELECT ''One''::TEXT;
+  END IF;
+END;' LANGUAGE plpgsql;
+
 CREATE TABLE temporal_data_type
 (
   "id"          INTEGER NOT NULL PRIMARY KEY,


### PR DESCRIPTION
See #311

If a stored procedure is invoked, and conditionally returns no result, the SQL Server driver may throw Exception.

In this commit, the SQLException is caught and logged at trace level.

There are tests that verify the behavior is ok with different databases (Pg and MSSQL).