### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/src/main/java/io/vertx/jdbcclient/FetchDirection.java
+++ b/src/main/java/io/vertx/jdbcclient/FetchDirection.java
@@ -15,8 +15,6 @@
  */
 package io.vertx.jdbcclient;
 
-import io.vertx.codegen.annotations.VertxGen;
-
 import java.sql.ResultSet;
 
 /**

--- a/src/main/java/io/vertx/jdbcclient/ResultSetConcurrency.java
+++ b/src/main/java/io/vertx/jdbcclient/ResultSetConcurrency.java
@@ -15,8 +15,6 @@
  */
 package io.vertx.jdbcclient;
 
-import io.vertx.codegen.annotations.VertxGen;
-
 import java.sql.ResultSet;
 
 /**

--- a/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCStatementHelper.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCStatementHelper.java
@@ -24,7 +24,6 @@ import io.vertx.jdbcclient.spi.JDBCEncoderImpl;
 
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.