### PR TITLE
Report dead connections to the pool

### DIFF
--- a/src/main/java/io/vertx/jdbcclient/impl/ConnectionImpl.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/ConnectionImpl.java
@@ -32,6 +32,8 @@ import io.vertx.sqlclient.spi.connection.ConnectionContext;
 import io.vertx.sqlclient.spi.protocol.*;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
 
 public class ConnectionImpl implements Connection {
 
@@ -44,6 +46,9 @@ public class ConnectionImpl implements Connection {
   final SocketAddress server;
   final SqlOptions sqlOptionsBackup;
   SqlOptions sqlOptions;
+  private volatile ConnectionContext holder;
+  private volatile boolean broken;
+  private volatile boolean closing;
 //  final TaskQueue statementsQueue = new TaskQueue();
 
 
@@ -63,7 +68,11 @@ public class ConnectionImpl implements Connection {
     sqlOptions = new SqlOptions(sqlOptionsBackup);
     PromiseInternal<Void> promise = context.owner().promise();
     context.<Void>executeBlocking(() -> {
-      conn.beginRequest();
+      try {
+        conn.beginRequest();
+      } catch (SQLException e) {
+        throw reportException(e);
+      }
       return null;
     }, false).onComplete(promise);
     return promise.future();
@@ -73,10 +82,55 @@ public class ConnectionImpl implements Connection {
     sqlOptions = null;
     PromiseInternal<Void> promise = context.owner().promise();
     context.<Void>executeBlocking(() -> {
-      conn.endRequest();
+      try {
+        conn.endRequest();
+      } catch (SQLException e) {
+        throw reportException(e);
+      }
       return null;
     }, false).onComplete(promise);
     return promise.future();
+  }
+
+  /**
+   * Latches connection-fatal failures and reports them to the connection holder.
+   *
+   * <p>A {@code java.sql.Connection} has no event channel: unlike the socket based clients a dead
+   * JDBC connection cannot notify its {@link ConnectionContext} of the disconnection. Without this
+   * hook a pooled connection that dies while pooled (database restart, server side idle timeout,
+   * a pooling {@code DataSource} invalidating the physical connection) is recycled forever, and
+   * every lease of it fails until the process is restarted. Reporting {@code handleClosed()} lets
+   * the pool remove the connection, exactly as it does when a socket based connection is closed.
+   */
+  private SQLException reportException(SQLException e) {
+    if (!closing && !broken && isFatal(e)) {
+      broken = true;
+      ConnectionContext h = holder;
+      if (h != null) {
+        context.runOnContext(v -> h.handleClosed());
+      }
+    }
+    return e;
+  }
+
+  private boolean isFatal(SQLException e) {
+    int depth = 0;
+    for (Throwable t = e; t != null && depth++ < 16; t = t.getCause()) {
+      if (t instanceof SQLNonTransientConnectionException || t instanceof SQLRecoverableException) {
+        return true;
+      }
+      if (t instanceof SQLException) {
+        String sqlState = ((SQLException) t).getSQLState();
+        if (sqlState != null && sqlState.startsWith("08")) {
+          return true;
+        }
+      }
+    }
+    try {
+      return conn.isClosed();
+    } catch (SQLException ignore) {
+      return true;
+    }
   }
 
   public java.sql.Connection getJDBCConnection() {
@@ -115,7 +169,15 @@ public class ConnectionImpl implements Connection {
 
   @Override
   public boolean isValid() {
-    return true;
+    if (broken) {
+      return false;
+    }
+    try {
+      // Connection#isClosed does not ping the server, it only reflects local state
+      return !conn.isClosed();
+    } catch (SQLException e) {
+      return false;
+    }
   }
 
   @Override
@@ -130,11 +192,12 @@ public class ConnectionImpl implements Connection {
 
   @Override
   public void init(ConnectionContext context) {
-
+    this.holder = context;
   }
 
   @Override
   public void close(ConnectionContext holder, Completable<Void> promise) {
+    closing = true;
     schedule(new JDBCClose(sqlOptions, null, null))
       .andThen(ar -> {
         if (metrics != null) {
@@ -197,10 +260,14 @@ public class ConnectionImpl implements Connection {
 
   public <T> Future<T> schedule(JDBCAction<T> action) {
     return context.executeBlocking(() -> {
-      // apply connection options
-      applyConnectionOptions(conn, sqlOptions);
-      // execute
-      return action.execute(conn);
+      try {
+        // apply connection options
+        applyConnectionOptions(conn, sqlOptions);
+        // execute
+        return action.execute(conn);
+      } catch (SQLException e) {
+        throw reportException(e);
+      }
     }/*, statementsQueue*/);
   }
 

--- a/src/test/java/io/vertx/jdbcclient/ConnectionInvalidationTest.java
+++ b/src/test/java/io/vertx/jdbcclient/ConnectionInvalidationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.jdbcclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLNonTransientConnectionException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A JDBC connection cannot notify the pool of its own death the way the socket based clients do, so
+ * the driver must report fatal failures to the pool instead. Before this was implemented, a pooled
+ * connection that died while pooled (database restart, server side idle timeout, a pooling
+ * {@code DataSource} invalidating the physical connection) was recycled forever: every lease of it
+ * failed with the same connection error until the process was restarted.
+ */
+@RunWith(VertxUnitRunner.class)
+public class ConnectionInvalidationTest {
+
+  /**
+   * Hands out real hsqldb connections wrapped in a proxy with a kill switch: once killed, every
+   * call except {@code close()}/{@code isClosed()} throws a fatal connection error, mimicking a
+   * connection the server has dropped.
+   */
+  static class KillableDataSource implements DataSource {
+
+    final List<AtomicBoolean> killSwitches = new CopyOnWriteArrayList<>();
+
+    @Override
+    public Connection getConnection() throws SQLException {
+      Connection real = DriverManager.getConnection("jdbc:hsqldb:mem:" + ConnectionInvalidationTest.class.getSimpleName());
+      AtomicBoolean killed = new AtomicBoolean();
+      killSwitches.add(killed);
+      InvocationHandler handler = (proxy, method, args) -> {
+        String name = method.getName();
+        if (killed.get() && !name.equals("close") && !name.equals("isClosed") && !name.equals("isValid")) {
+          throw new SQLNonTransientConnectionException("connection failure", "08003");
+        }
+        try {
+          return method.invoke(real, args);
+        } catch (InvocationTargetException e) {
+          throw e.getCause();
+        }
+      };
+      return (Connection) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{Connection.class}, handler);
+    }
+
+    void killAll() {
+      for (AtomicBoolean killed : killSwitches) {
+        killed.set(true);
+      }
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+      return getConnection();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+      return null;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) {
+    }
+
+    @Override
+    public int getLoginTimeout() {
+      return 0;
+    }
+
+    @Override
+    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
+      throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+      throw new SQLException();
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+      return false;
+    }
+  }
+
+  private Vertx vertx;
+  private KillableDataSource dataSource;
+  private Pool client;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+    dataSource = new KillableDataSource();
+    client = JDBCPool.pool(vertx, dataSource, new PoolOptions().setMaxSize(1));
+  }
+
+  @After
+  public void after(TestContext ctx) {
+    client.close().onComplete(ctx.asyncAssertSuccess(v -> {
+      vertx.close().onComplete(ctx.asyncAssertSuccess());
+    }));
+  }
+
+  @Test
+  public void testPoolRecoversWhenPooledConnectionDies(TestContext should) {
+    Async test = should.async();
+    // lease the single pooled connection once so it is established and recycled
+    client
+      .query("SELECT 1 FROM (VALUES(0))")
+      .execute()
+      .onFailure(should::fail)
+      .onSuccess(rows1 -> {
+        // the connection dies while sitting in the pool
+        dataSource.killAll();
+        // this lease draws the dead connection and must fail
+        client
+          .query("SELECT 1 FROM (VALUES(0))")
+          .execute()
+          .onSuccess(rows -> should.fail("query on a dead connection should not succeed"))
+          .onFailure(err -> {
+            // the dead connection was reported and must be removed: the pool serves a fresh one
+            // (removal is asynchronous, so allow a few attempts)
+            awaitRecovery(should, test, 10);
+          });
+      });
+  }
+
+  private void awaitRecovery(TestContext should, Async test, int remainingAttempts) {
+    client
+      .query("SELECT 1 FROM (VALUES(0))")
+      .execute()
+      .onSuccess(rows -> {
+        should.assertEquals(1, rows.size());
+        test.complete();
+      })
+      .onFailure(err -> {
+        if (remainingAttempts > 0) {
+          vertx.setTimer(100, id -> awaitRecovery(should, test, remainingAttempts - 1));
+        } else {
+          should.fail("the pool did not recover after the pooled connection died: " + err);
+        }
+      });
+  }
+}


### PR DESCRIPTION
Motivation:

A pooled JDBC connection that dies while pooled (database restart, server-side idle timeout such as MySQL `wait_timeout`, a pooling `DataSource` invalidating the physical connection) is re-leased forever: every lease of it fails with the same connection error until the process restarts. Unlike the socket-based clients, a JDBC connection has no event channel to signal its death — `ConnectionImpl.init()` discards the `ConnectionContext`, `isValid()` is hardcoded to `true`, and the pool recycles leases unconditionally. Observed in production on 5.1.3: after MySQL killed idle pooled connections, every request drawing the dead slot failed with `SQLException: Connection is closed` until the pod was restarted.

Changes:

Latch fatal `SQLException`s (connection SQLState class 08, `SQLNonTransientConnectionException`, `SQLRecoverableException`, or a locally closed connection) wherever JDBC work executes, and report `handleClosed()` to the connection holder so the pool removes the dead connection — the same removal path the socket-based clients use. `isValid()` now reflects the actual connection state.

`ConnectionInvalidationTest` reproduces the bug: it kills a pooled connection and asserts the pool serves a fresh connection afterwards; without the fix the pool keeps re-leasing the dead one.

Companion fix in the shared pool: eclipse-vertx/vertx-sql-client `SqlConnectionPool#acquire` leaks the lease and reports a null cause when the `afterAcquire` hook fails (branch `andrewkav/vertx-sql-client:fix/pool-acquire-hook-failure-cleanup`, PR to follow).

Conformance:

ECA signed; commit is signed off. Some portions of this content were created with the assistance of Claude Code.
