### PR TITLE
Upgrade test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2011-2026 The original author or authors
   ~
-  ~ This program and the accompanying materials are made available under the
-  ~ terms of the Eclipse Public License 2.0 which is available at
-  ~ http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-  ~ which is available at https://www.apache.org/licenses/LICENSE-2.0.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ and Apache License v2.0 which accompanies this distribution.
   ~
-  ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  ~      The Eclipse Public License is available at
+  ~      http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~      The Apache License v2.0 is available at
+  ~      http://www.opensource.org/licenses/apache2.0.php
+  ~
+  ~ You may elect to redistribute this code under either of these licenses.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>io.vertx</groupId>
@@ -90,22 +97,23 @@
       <version>2.7.4</version>
       <scope>test</scope>
     </dependency>
+    <!-- Derby 10.17+ requires Java 21+; using 10.15.2.0 for Java 11 compatibility -->
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.14.2.0</version>
+      <version>10.15.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.200</version>
+      <version>2.4.240</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>8.0.33</version>
+      <version>9.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -129,7 +137,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>7.2.2.jre8</version>
+      <version>13.4.0.jre11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -139,20 +147,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ru.yandex.clickhouse</groupId>
+      <groupId>com.clickhouse</groupId>
       <artifactId>clickhouse-jdbc</artifactId>
-      <version>0.2.4</version>
+      <version>0.9.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc8</artifactId>
-      <version>21.1.0.0</version>
-      <scope>test</scope>
+      <artifactId>ojdbc11</artifactId>
+      <version>21.21.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>oracle-xe</artifactId>
+      <artifactId>oracle-free</artifactId>
       <version>${testcontainers}</version>
       <scope>test</scope>
     </dependency>
@@ -165,7 +172,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.3.3</version>
+      <version>42.7.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/io/vertx/it/ClickHouseTest.java
+++ b/src/test/java/io/vertx/it/ClickHouseTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2011-2026 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
 package io.vertx.it;
 
 import io.vertx.core.Vertx;
@@ -15,7 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.clickhouse.ClickHouseContainer;
 
 @RunWith(VertxUnitRunner.class)
 public class ClickHouseTest {
@@ -27,10 +43,13 @@ public class ClickHouseTest {
   @Before
   public void setUp() {
     vertx = Vertx.vertx();
-    container = new ClickHouseContainer("yandex/clickhouse-server:20.8");
+    container = new ClickHouseContainer("clickhouse/clickhouse-server:21.11-alpine");
     container.withInitScript("init-clickhouse.sql");
     container.start();
-    JDBCConnectOptions connectOptions = new JDBCConnectOptions().setJdbcUrl("jdbc:clickhouse://localhost:" + container.getMappedPort(8123) + "/default");
+    JDBCConnectOptions connectOptions = new JDBCConnectOptions()
+      .setJdbcUrl(container.getJdbcUrl())
+      .setUser(container.getUsername())
+      .setPassword(container.getPassword());
     client = JDBCPool.pool(vertx, connectOptions, new PoolOptions());
   }
 


### PR DESCRIPTION
Some test dependencies have security issues and others are outdated (e.g. Clickhouse, Oracle).