### PR TITLE
Test with Derby only on Java 21+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,6 @@
       <version>2.7.4</version>
       <scope>test</scope>
     </dependency>
-    <!-- Derby 10.17+ requires Java 21+; using 10.15.2.0 for Java 11 compatibility -->
-    <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
-      <version>10.15.2.0</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
@@ -257,4 +250,22 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>Java-21</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.derby</groupId>
+          <artifactId>derby</artifactId>
+          <version>10.17.1.0</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/src/test/java/io/vertx/jdbcclient/JDBCTypesTest.java
+++ b/src/test/java/io/vertx/jdbcclient/JDBCTypesTest.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2011-2014 The original author or authors
- * ------------------------------------------------------
+ * Copyright (c) 2011-2026 The original author or authors
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Apache License v2.0 which accompanies this distribution.
  *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
  *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
  *
  * You may elect to redistribute this code under either of these licenses.
  */
@@ -18,13 +18,14 @@ package io.vertx.jdbcclient;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.DBConfigs;
-import io.vertx.jdbcclient.spi.JDBCEncoderImpl;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.jdbcclient.impl.actions.JDBCColumnDescriptor;
+import io.vertx.jdbcclient.spi.JDBCEncoderImpl;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Tuple;
 import junit.framework.AssertionFailedError;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +45,7 @@ import java.util.concurrent.TimeoutException;
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
 @RunWith(VertxUnitRunner.class)
-public class JDBCTypesTestBase extends ClientTestBase {
+public class JDBCTypesTest extends ClientTestBase {
 
   private static final List<String> SQL = new ArrayList<>();
 
@@ -74,7 +75,8 @@ public class JDBCTypesTestBase extends ClientTestBase {
 
   @BeforeClass
   public static void createDb() throws Exception {
-    Connection conn = DriverManager.getConnection(DBConfigs.derby(JDBCTypesTestBase.class).getString("url"));
+    Assume.assumeTrue("Derby requires Java 21+", Runtime.version().feature() >= 21);
+    Connection conn = DriverManager.getConnection(DBConfigs.derby(JDBCTypesTest.class).getString("url"));
     for (String sql : SQL) {
       conn.createStatement().execute(sql);
     }


### PR DESCRIPTION
- Security update for Derby
- Renamed JDBCTypesTestBase to JDBCTypesTest so that it gets executed

Derby requires to be set in a separate profile otherwise it breaks JDBC driver loading on Java 11.