### PR TITLE
Fix the order of the values in the stored procedure output row

### DIFF
--- a/src/main/java/io/vertx/jdbcclient/impl/actions/CallableOutParams.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/actions/CallableOutParams.java
@@ -1,8 +1,8 @@
 package io.vertx.jdbcclient.impl.actions;
 
 import java.sql.JDBCType;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 public interface CallableOutParams extends Map<Integer, JDBCTypeWrapper> {
 
@@ -22,7 +22,7 @@ public interface CallableOutParams extends Map<Integer, JDBCTypeWrapper> {
     return this.put(key, JDBCTypeWrapper.of(jdbcType));
   }
 
-  class CallableOutParamsImpl extends HashMap<Integer, JDBCTypeWrapper> implements CallableOutParams {
-
+  // the positions are kept sorted, the values of the output row follow the order of the OUT parameters
+  class CallableOutParamsImpl extends TreeMap<Integer, JDBCTypeWrapper> implements CallableOutParams {
   }
 }

--- a/src/test/java/io/vertx/jdbcclient/JDBCPoolStoredProceduresTest.java
+++ b/src/test/java/io/vertx/jdbcclient/JDBCPoolStoredProceduresTest.java
@@ -62,6 +62,14 @@ public class JDBCPoolStoredProceduresTest extends ClientTestBase {
     SQL.add("create procedure times2(INOUT param INT)\n" +
       "  modifies sql data\n" +
       "  SET param = param * 2");
+    SQL.add("drop procedure if exists out_params_order");
+    SQL.add("create procedure out_params_order(IN p1 INT, IN p2 INT, IN p3 INT, IN p4 INT, IN p5 INT, IN p6 INT, IN p7 INT, IN p8 INT, IN p9 INT, IN p10 INT, IN p11 INT, IN p12 INT, IN p13 INT, IN p14 INT, OUT o1 BIGINT, OUT o2 BIGINT, OUT o3 BIGINT)\n" +
+      "  modifies sql data\n" +
+      "  BEGIN ATOMIC\n" +
+      "    SET o1 = 101;\n" +
+      "    SET o2 = 102;\n" +
+      "    SET o3 = 103;\n" +
+      "  END");
   }
 
   public static void resetDb() throws SQLException {
@@ -130,6 +138,38 @@ public class JDBCPoolStoredProceduresTest extends ClientTestBase {
         should.assertEquals(1, rows.size());
         should.assertTrue(rows.property(JDBCPool.OUTPUT));
         should.assertEquals("Doe", rows.iterator().next().getString(0));
+        test.complete();
+      });
+  }
+
+  @Test
+  public void testStoredProcedureOutParamsOrder(TestContext should) {
+    final Async test = should.async();
+
+    // the OUT parameters are at positions 15, 16 and 17
+    String sql = "{call out_params_order(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)}";
+
+    Tuple params = Tuple.tuple();
+    for (int i = 0; i < 14; i++) {
+      params.addInteger(0);
+    }
+    for (int i = 0; i < 3; i++) {
+      params.addValue(SqlOutParam.OUT(JDBCType.BIGINT));
+    }
+
+    client
+      .preparedQuery(sql)
+      .execute(params)
+      .onFailure(should::fail)
+      .onSuccess(rows -> {
+        should.assertNotNull(rows);
+        should.assertEquals(1, rows.size());
+        should.assertTrue(rows.property(JDBCPool.OUTPUT));
+        // the output row must follow the parameter positions
+        Row row = rows.iterator().next();
+        should.assertEquals(101L, row.getLong(0));
+        should.assertEquals(102L, row.getLong(1));
+        should.assertEquals(103L, row.getLong(2));
         test.complete();
       });
   }


### PR DESCRIPTION
See #365

`CallableOutParams` is backed by a `HashMap`, so `decodeOutput` iterates the OUT
parameter positions in bucket order instead of position order. The two match only
while every position is below the capacity of the map, so a call with an OUT parameter
at position 16 or above puts the values in the output row in the wrong order. The row
is unlabeled and read by index, so the caller silently gets the value of another OUT
parameter. Hit in production on SQL Server with the OUT parameters at 15, 16 and 17.

Backing the map with a `TreeMap` keeps the positions sorted. The test calls a procedure
with 14 IN and 3 OUT parameters and fails on master with `Not equals : 101 != 102`.

Some portions of this content were created with the assistance of Claude Code.