### PR TITLE
Report a failing statement that comes after an update count

### DIFF
--- a/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCQueryAction.java
+++ b/src/main/java/io/vertx/jdbcclient/impl/actions/JDBCQueryAction.java
@@ -80,11 +80,34 @@ public abstract class JDBCQueryAction<C, R> extends AbstractJDBCAction<JDBCRespo
       }
     }
 
+    drainRemainingResults(statement);
+
     if (!outParams.isEmpty()) {
       decodeOutput((CallableStatement) statement, outParams, response);
     }
 
     return response;
+  }
+
+  /**
+   * Reads the rest of the result stream, if any.
+   *
+   * The decoding above relies on {@link Statement#getMoreResults()}, which returns {@code false}
+   * both when there is no more result and when the next result is an update count, so the decoding
+   * stops at the first update count and whatever follows it is left unread. When one of the
+   * remaining statements failed, its {@link SQLException} is never raised and the query completes
+   * successfully although the database did not run it.
+   *
+   * Only the result sets that come before the first update count are returned, so a query that
+   * starts with an update returns no result set at all, whatever the statements that follow it
+   * return. The remaining results are therefore read but not decoded: what the query returns does
+   * not change, only the exception of the failed statement has to reach the caller.
+   */
+  private void drainRemainingResults(Statement statement) throws SQLException {
+    // the stream is over when the next result is not a result set and the update count is -1
+    while (statement.getMoreResults() || statement.getUpdateCount() != -1) {
+      // nothing to do, the results are only walked through to reach the end of the stream
+    }
   }
 
   protected JDBCResponse<R> decode(Statement statement, int[] returnedBatchResult, boolean returnedKeys) throws SQLException {

--- a/src/test/java/io/vertx/it/MSSQLTest.java
+++ b/src/test/java/io/vertx/it/MSSQLTest.java
@@ -212,6 +212,26 @@ public class MSSQLTest {
   }
 
   @Test
+  public void testErrorAfterUpdateCount() throws Exception {
+    final Pool client = initJDBCPool();
+
+    // the first result of the statement is an update count, the error comes after the result set
+    String sql = "insert into multi_statement (id) values (?)\n" +
+      "select id from multi_statement\n" +
+      "insert into multi_statement (id) values (?)";
+
+    try {
+      client
+        .preparedQuery(sql)
+        // the second insert reuses the key of the row created by the init script
+        .execute(Tuple.of(2, 1))
+        .await(20, TimeUnit.SECONDS);
+      fail("the primary key violation should be reported to the caller");
+    } catch (Exception expected) {
+    }
+  }
+
+  @Test
   public void testConditionalStoredProcedure() throws Exception {
     final Pool client = initJDBCPool();
 

--- a/src/test/resources/init-mssql.sql
+++ b/src/test/resources/init-mssql.sql
@@ -227,3 +227,14 @@ CREATE TABLE special_datatype
 
 INSERT INTO special_datatype (id, dto)
 VALUES (1, '2020-12-12 19:30:30.12345Z');
+
+-- table for testing that an error raised by a statement other than the first is reported
+DROP TABLE IF EXISTS multi_statement;
+CREATE TABLE multi_statement
+(
+    id integer NOT NULL,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO multi_statement (id)
+VALUES (1);


### PR DESCRIPTION
See #367

`JDBCQueryAction.decode` walks the results with `Statement.getMoreResults()`, which
returns `false` both when the stream is over and when the next result is an update
count, so the decoding stops at the first update count and the rest of the stream is
never read. When one of the remaining statements failed, its `SQLException` is never
raised and the query completes successfully although the database did not run it.

Reading the stream to the end after the decoding brings that exception back to the
caller. The remaining results are discarded rather than decoded, so what a query
returns does not change.

The test in `MSSQLTest` runs an insert, a select and an insert that violates the
primary key; on master it completes without an error. Draining the stream was checked
against HSQLDB, SQL Server, MySQL and PostgreSQL: 104, 8, 5 and 13 tests green.

Some portions of this content were created with the assistance of Claude Code.